### PR TITLE
fix invalid printf formats

### DIFF
--- a/examples/multiroot_ex.ml
+++ b/examples/multiroot_ex.ml
@@ -27,7 +27,7 @@ let print_state n =
   fun iter solv ->
     Multiroot.NoDeriv.get_state solv ~x ~f () ;
     Printf.printf 
-      "iter = %3u x = %+ .3f %+ .3f f(x) = %+ .3e %+ .3e\n"
+      "iter = %3u x = %+.3f %+.3f f(x) = %+.3e %+.3e\n"
       iter x.{0} x.{1} f.{0} f.{1} ;
     flush stdout
 
@@ -72,7 +72,7 @@ let print_state_deriv n =
   fun iter solv ->
     Multiroot.Deriv.get_state solv ~x ~f () ;
     Printf.printf 
-      "iter = %3u x = %+ .3f %+ .3f f(x) = %+ .3e %+ .3e\n"
+      "iter = %3u x = %+.3f %+.3f f(x) = %+.3e %+.3e\n"
       iter x.{0} x.{1} f.{0} f.{1} ;
     flush stdout
 


### PR DESCRIPTION
There are some format strings that are "invalid" in the gsl-ocaml sources.

In general, invalid formats are nonsensical format strings that were accepted in OCaml 4.01.0 and earlier, but whose semantics is unspecified. They are still accepted by the new Printf implementation of OCaml 4.02.0 but in some cases with different semantics, and they will be statically rejected by OCaml 4.03.0.

You can check for them in OCaml 4.02.0 with the flag -strict-formats.

In the case of gsl-ocaml, I think the behavior has not changed between 4.01.0 and 4.02.0. The only kind of invalid format is "%+ .3f". This is considered invalid beause the '+' flag means that positive numbers must be prefixed with a '+' character, and the ' ' flag means that positive numbers must be prefixed with a space, so these two flags are incompatible. Even though the behaviour has not changed, you should take the opportunity to review the code and fix the format. The patch changes it to "%+.3f", which keeps the behaviour unchanged, but that might still be wrong.
