### PR TITLE
Fix to compile with current version of GSL (1.16).

### DIFF
--- a/lib/mlgsl_sf.c
+++ b/lib/mlgsl_sf.c
@@ -258,7 +258,7 @@ SF3(ellint_F, Double_val, Double_val, GSL_MODE_val)
 SF3(ellint_E, Double_val, Double_val, GSL_MODE_val)
 SF4(ellint_P, Double_val, Double_val, Double_val, GSL_MODE_val)
 
-#if GSL_MAJOR_VERSION > 1 || (GSL_MAJOR_VERSION >= 1 && GSL_MINOR_VERSION >= 17)
+#if GSL_MAJOR_VERSION > 1 || (GSL_MAJOR_VERSION >= 1 && GSL_MINOR_VERSION >= 16)
 SF3(ellint_D, Double_val, Double_val, GSL_MODE_val)
 #else
 CAMLprim value ml_gsl_sf_ellint_D(value arg1, value arg2, value arg3)


### PR DESCRIPTION
Dear Markus,

I just checked out gsl-ocaml and tried to compile. Unfortunately it failed.

Here is the fix for my machine (ALT Linux Sisyphus, ocaml 4.02.2, gcc 5.1.1, libgsl-1.16 (current)). 
I am not sure the fix is correct, but I still think that I have to notify you. :-)

Thanks for you work,
    Andrey.