### PR TITLE
Fix dune rules

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -54,29 +54,23 @@
       ; NOTE: for limiting excessive warning about unused parameters
       -Wno-unused-parameter))
   (c_library_flags (:include c_library_flags.sexp))
-  (libraries bigarray)
-)
+  (libraries bigarray))
 
 (rule
   (targets c_flags.sexp c_library_flags.sexp gsl_include.sexp)
-  (deps (:discover config/discover.exe))
-  (action (run %{discover}))
-)
+  (action (run config/discover.exe)))
 
 (rule
   (targets cdf.mli cdf.ml mlgsl_cdf.c)
-  (deps config/do_cdf.exe gsl_include.sexp)
-  (action (run config/do_cdf.exe))
-)
+  (deps gsl_include.sexp)
+  (action (run config/do_cdf.exe)))
 
 (rule
   (targets const.mli const.ml)
-  (deps config/do_const.exe gsl_include.sexp)
-  (action (run config/do_const.exe))
-)
+  (deps gsl_include.sexp)
+  (action (run config/do_const.exe)))
 
 (rule
   (targets sf.mli sf.ml)
-  (deps config/do_sf.exe sf.mli.q)
-  (action (run config/do_sf.exe))
-)
+  (deps gsl_include.sexp sf.mli.q)
+  (action (run config/do_sf.exe)))


### PR DESCRIPTION
* Add gsl_include.sexp when running do_sf.exe
* Fix formatting of dune rules
* Simplify rules by removing explicit dependency on exe's. Dune adds
this dependency automatically when using `run`.