### PR TITLE
Add missing version import for multivariate gaussian

### DIFF
--- a/src/mlgsl_randist.c
+++ b/src/mlgsl_randist.c
@@ -3,6 +3,7 @@
 /* Distributed under the terms of the GPL version 3         */
 
 #include <gsl/gsl_randist.h>
+#include <gsl/gsl_version.h>
 
 #include <caml/alloc.h>
 #include <caml/memory.h>

--- a/src/mlgsl_randist.c
+++ b/src/mlgsl_randist.c
@@ -234,17 +234,32 @@ ML3(gsl_ran_binomial_tpe, Rng_val, Double_val, Int_val, Val_int)
 ML3(gsl_ran_binomial_pdf, Int_val, Double_val, Int_val, copy_double)
 
 /* MULTINOMIAL */
+CAMLprim value ml_gsl_ran_multinomial_inplace(value rng, value n, value p, value ret)
+{
+  mlsize_t K = Double_array_length(p);
+  LOCALARRAY(unsigned int, N, K); 
+  gsl_ran_multinomial(Rng_val(rng), K, Int_val(n), Double_array_val(p), N);
+  {
+    mlsize_t i; 
+    for(i=0; i<K; i++) {
+      Store_field(ret, i, Val_int(N[i]));
+    }
+  }
+  return ret;
+}
+
 CAMLprim value ml_gsl_ran_multinomial(value rng, value n, value p)
 {
   mlsize_t K = Double_array_length(p);
   LOCALARRAY(unsigned int, N, K); 
-  value r;
   gsl_ran_multinomial(Rng_val(rng), K, Int_val(n), Double_array_val(p), N);
+  value r;
   {
-    mlsize_t i;
+    mlsize_t i; 
     r = alloc(K, 0);
-    for(i=0; i<K; i++)
+    for(i=0; i<K; i++) {
       Store_field(r, i, Val_int(N[i]));
+    }
   }
   return r;
 }

--- a/src/mlgsl_rng.c
+++ b/src/mlgsl_rng.c
@@ -126,6 +126,7 @@ value ml_gsl_rng_set_default_seed(value seed)
 
 value ml_gsl_rng_alloc(value type)
 {
+  void* x = malloc(2 * 16);
   value r;
   Abstract_ptr(r,gsl_rng_alloc(Rngtype_val(type))); 
   return r;

--- a/src/randist.ml
+++ b/src/randist.ml
@@ -281,6 +281,9 @@ external binomial_pdf : int -> p:float -> n:int -> float
     = "ml_gsl_ran_binomial_pdf"
 
 (* MULTINOMIAL *)
+external multinomial_inplace : Rng.t -> n:int -> p:float array -> ret:int array -> int array
+    = "ml_gsl_ran_multinomial_inplace"
+
 external multinomial : Rng.t -> n:int -> p:float array -> int array
     = "ml_gsl_ran_multinomial"
 

--- a/src/randist.mli
+++ b/src/randist.mli
@@ -218,6 +218,8 @@ external binomial_tpe : Rng.t -> p:float -> n:int -> int
 external binomial_pdf : int -> p:float -> n:int -> float
   = "ml_gsl_ran_binomial_pdf"
 
+external multinomial_inplace : Rng.t -> n:int -> p:float array -> ret:int array -> int array
+    = "ml_gsl_ran_multinomial_inplace"
 external multinomial : Rng.t -> n:int -> p:float array -> int array
     = "ml_gsl_ran_multinomial"
 external multinomial_pdf : p:float array -> n:int array -> float


### PR DESCRIPTION
The `#ifdef` was not triggering due to the version number not being imported.
The bindings themselves seem to work once this is fixed, at least in my comparison between some original and ported c code.