### PR TITLE
OCaml 5.0 compatibility

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -34,6 +34,6 @@
     sum_ex
     wavelet_ex
   )
-  (libraries gsl)
+  (libraries gsl unix)
   (modes byte exe)
 )

--- a/src/config/do_cdf.ml
+++ b/src/config/do_cdf.ml
@@ -82,7 +82,7 @@ let print_c_args buf args =
 
 let print_c oc (fun_name, args) =
   fprintf oc
-    "ML%d(gsl_cdf_%s,%a copy_double)\n"
+    "ML%d(gsl_cdf_%s,%a caml_copy_double)\n"
     (List.length args)
     fun_name
     print_c_args args

--- a/src/mlgsl_blas.c
+++ b/src/mlgsl_blas.c
@@ -19,21 +19,21 @@ CAMLprim value ml_gsl_blas_ddot(value X, value Y)
   _DECLARE_VECTOR2(X, Y);
   _CONVERT_VECTOR2(X, Y);
   gsl_blas_ddot(&v_X, &v_Y, &r);
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 CAMLprim value ml_gsl_blas_dnrm2(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_dnrm2(&v_X));
+  return caml_copy_double(gsl_blas_dnrm2(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_dasum(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_dasum(&v_X));
+  return caml_copy_double(gsl_blas_dasum(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_idamax(value X)

--- a/src/mlgsl_blas_complex.c
+++ b/src/mlgsl_blas_complex.c
@@ -35,14 +35,14 @@ CAMLprim value ml_gsl_blas_znrm2(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_dznrm2(&v_X));
+  return caml_copy_double(gsl_blas_dznrm2(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_zasum(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_dzasum(&v_X));
+  return caml_copy_double(gsl_blas_dzasum(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_izamax(value X)

--- a/src/mlgsl_blas_complex_float.c
+++ b/src/mlgsl_blas_complex_float.c
@@ -37,14 +37,14 @@ CAMLprim value ml_gsl_blas_scnrm2(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_scnrm2(&v_X));
+  return caml_copy_double(gsl_blas_scnrm2(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_scasum(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_scasum(&v_X));
+  return caml_copy_double(gsl_blas_scasum(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_icamax(value X)

--- a/src/mlgsl_blas_float.c
+++ b/src/mlgsl_blas_float.c
@@ -19,7 +19,7 @@ CAMLprim value ml_gsl_blas_sdsdot(value alpha, value X, value Y)
   _DECLARE_VECTOR2(X, Y);
   _CONVERT_VECTOR2(X, Y);
   gsl_blas_sdsdot(Double_val(alpha), &v_X, &v_Y, &r);
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 CAMLprim value ml_gsl_blas_dsdot(value X, value Y)
@@ -28,7 +28,7 @@ CAMLprim value ml_gsl_blas_dsdot(value X, value Y)
   _DECLARE_VECTOR2(X, Y);
   _CONVERT_VECTOR2(X, Y);
   gsl_blas_dsdot(&v_X, &v_Y, &r);
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 CAMLprim value ml_gsl_blas_sdot(value X, value Y)
@@ -37,21 +37,21 @@ CAMLprim value ml_gsl_blas_sdot(value X, value Y)
   _DECLARE_VECTOR2(X, Y);
   _CONVERT_VECTOR2(X, Y);
   gsl_blas_sdot(&v_X, &v_Y, &r);
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 CAMLprim value ml_gsl_blas_snrm2(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_snrm2(&v_X));
+  return caml_copy_double(gsl_blas_snrm2(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_sasum(value X)
 {
   _DECLARE_VECTOR(X);
   _CONVERT_VECTOR(X);
-  return copy_double(gsl_blas_sasum(&v_X));
+  return caml_copy_double(gsl_blas_sasum(&v_X));
 }
 
 CAMLprim value ml_gsl_blas_isamax(value X)

--- a/src/mlgsl_cheb.c
+++ b/src/mlgsl_cheb.c
@@ -40,7 +40,7 @@ CAMLprim value ml_gsl_cheb_init(value cs, value f, value a, value b)
   CAMLreturn(Val_unit);
 }
 
-ML2(gsl_cheb_eval, CHEB_VAL, Double_val, copy_double)
+ML2(gsl_cheb_eval, CHEB_VAL, Double_val, caml_copy_double)
 
 CAMLprim value ml_gsl_cheb_eval_err(value cheb, value x)
 {
@@ -49,7 +49,7 @@ CAMLprim value ml_gsl_cheb_eval_err(value cheb, value x)
   return copy_two_double_arr(res, err);
 }
 
-ML3(gsl_cheb_eval_n, CHEB_VAL, Int_val, Double_val, copy_double)
+ML3(gsl_cheb_eval_n, CHEB_VAL, Int_val, Double_val, caml_copy_double)
 
 CAMLprim value ml_gsl_cheb_eval_n_err(value cheb, value order, value x)
 {

--- a/src/mlgsl_cheb.c
+++ b/src/mlgsl_cheb.c
@@ -27,7 +27,7 @@ CAMLprim value ml_gsl_cheb_coefs(value c)
   CAMLlocal1(a);
   gsl_cheb_series *cs = CHEB_VAL(c);
   size_t len = cs->order + 1;
-  a = alloc(len * Double_wosize, Double_array_tag);
+  a = caml_alloc(len * Double_wosize, Double_array_tag);
   memcpy(Bp_val(a), cs->c, len * sizeof (double));
   CAMLreturn(a);
 }

--- a/src/mlgsl_combi.c
+++ b/src/mlgsl_combi.c
@@ -8,7 +8,7 @@ static void combi_of_val(gsl_combination *c, value vc)
 {
     c->n = Int_val(Field(vc, 0));
     c->k = Int_val(Field(vc, 1));
-    c->data = Data_bigarray_val(Field(vc, 2));
+    c->data = Caml_ba_data_val(Field(vc, 2));
 }
 
 CAMLprim value ml_gsl_combination_init_first(value vc)

--- a/src/mlgsl_complex.c
+++ b/src/mlgsl_complex.c
@@ -38,7 +38,7 @@ CAMLprim value ml_gsl_complex_logabs(value Z)
 {
   _DECLARE_COMPLEX(Z);
   _CONVERT_COMPLEX(Z);
-  return copy_double(gsl_complex_logabs(z_Z));
+  return caml_copy_double(gsl_complex_logabs(z_Z));
 }
 
 

--- a/src/mlgsl_error.c
+++ b/src/mlgsl_error.c
@@ -35,7 +35,7 @@ static void ml_gsl_error_handler(const char *reason, const char *file,
   else if (GSL_CONTINUE <= gsl_errno && gsl_errno <= GSL_FAILURE)
     ml_errno = gsl_errno + 2;
   else
-    failwith("invalid GSL error code");
+    caml_failwith("invalid GSL error code");
 
   exn_msg = caml_copy_string(reason);
   caml_callback2(Field(*ml_gsl_err_handler,0), Val_int(ml_errno), exn_msg);

--- a/src/mlgsl_fft.c
+++ b/src/mlgsl_fft.c
@@ -28,9 +28,9 @@ static void check_layout(value fft_arr,
     if(!layout_exn) {
       layout_exn = caml_named_value("mlgsl_layout_exn");
       if(!layout_exn) /* Gromeleu */
-	invalid_argument("wrong fft_array layout");
+	caml_invalid_argument("wrong fft_array layout");
     }
-    raise_constant(*layout_exn);
+    caml_raise_constant(*layout_exn);
   }
 }
 

--- a/src/mlgsl_fit.c
+++ b/src/mlgsl_fit.c
@@ -36,7 +36,7 @@ CAMLprim value ml_gsl_fit_linear(value wo, value x, value y)
 		    Double_array_val(y), 1, N,
 		    &c0, &c1, &cov00, &cov01, &cov11, &sumsq);
   }
-  r=alloc_small(6 * Double_wosize, Double_array_tag);
+  r=caml_alloc_small(6 * Double_wosize, Double_array_tag);
   Store_double_field(r, 0, c0);
   Store_double_field(r, 1, c1);
   Store_double_field(r, 2, cov00);
@@ -80,7 +80,7 @@ CAMLprim value ml_gsl_fit_mul(value wo, value x, value y)
 		 Double_array_val(y), 1, N,
 		 &c1, &cov11, &sumsq);
   }
-  r=alloc_small(3 * Double_wosize, Double_array_tag);
+  r=caml_alloc_small(3 * Double_wosize, Double_array_tag);
   Store_double_field(r, 0, c1);
   Store_double_field(r, 1, cov11);
   Store_double_field(r, 2, sumsq);

--- a/src/mlgsl_fit.c
+++ b/src/mlgsl_fit.c
@@ -130,7 +130,7 @@ CAMLprim value ml_gsl_multifit_linear(value wo, value x, value y,
     gsl_multifit_wlinear(&m_x, &v_w, &v_y, &v_c, &m_cov, 
 			 &chisq, MultifitWS_val(ws));
   }
-  return copy_double(chisq);
+  return caml_copy_double(chisq);
 }
 
 CAMLprim value ml_gsl_multifit_linear_bc(value *args, int argc)

--- a/src/mlgsl_fun.c
+++ b/src/mlgsl_fun.c
@@ -91,7 +91,7 @@ double gsl_monte_callback_fast(double *x_arr, size_t dim, void *params)
 /* MULTIROOT CALLBACKS */
 int gsl_multiroot_callback(const gsl_vector *x, void *params, gsl_vector *F)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr, f_barr;
   int len = x->size;
@@ -110,7 +110,7 @@ int gsl_multiroot_callback(const gsl_vector *x, void *params, gsl_vector *F)
 
 int gsl_multiroot_callback_f(const gsl_vector *x, void *params, gsl_vector *F)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr, f_barr;
   int len = x->size;
@@ -129,7 +129,7 @@ int gsl_multiroot_callback_f(const gsl_vector *x, void *params, gsl_vector *F)
 
 int gsl_multiroot_callback_df(const gsl_vector *x, void *params, gsl_matrix *J)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr, j_barr;
   int len = x->size;
@@ -150,7 +150,7 @@ int gsl_multiroot_callback_df(const gsl_vector *x, void *params, gsl_matrix *J)
 int gsl_multiroot_callback_fdf(const gsl_vector *x, void *params, 
 			   gsl_vector *F, gsl_matrix *J)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr, f_barr, j_barr;
   int len = x->size;
@@ -176,7 +176,7 @@ int gsl_multiroot_callback_fdf(const gsl_vector *x, void *params,
 /* MULTIMIN CALLBACKS */
 double gsl_multimin_callback(const gsl_vector *x, void *params)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr;
   int len = x->size;
@@ -193,7 +193,7 @@ double gsl_multimin_callback(const gsl_vector *x, void *params)
 
 double gsl_multimin_callback_f(const gsl_vector *x, void *params)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr;
   int len = x->size;
@@ -210,7 +210,7 @@ double gsl_multimin_callback_f(const gsl_vector *x, void *params)
 
 void gsl_multimin_callback_df(const gsl_vector *x, void *params, gsl_vector *G)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr, g_barr;
   int len = x->size;
@@ -229,7 +229,7 @@ void gsl_multimin_callback_df(const gsl_vector *x, void *params, gsl_vector *G)
 void gsl_multimin_callback_fdf(const gsl_vector *x, void *params, 
 			       double *f, gsl_vector *G)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *p=params;
   value x_barr, g_barr;
   int len = x->size;
@@ -252,7 +252,7 @@ void gsl_multimin_callback_fdf(const gsl_vector *x, void *params,
 /* MULTIFIT CALLBACKS */
 int gsl_multifit_callback_f(const gsl_vector *X, void *params, gsl_vector *F)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *parms=params;
   value x_barr, f_barr;
   size_t p = X->size;
@@ -272,7 +272,7 @@ int gsl_multifit_callback_f(const gsl_vector *X, void *params, gsl_vector *F)
 
 int gsl_multifit_callback_df(const gsl_vector *X, void *params, gsl_matrix *J)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *parms=params;
   value x_barr, j_barr;
   size_t p = X->size;
@@ -297,7 +297,7 @@ int gsl_multifit_callback_df(const gsl_vector *X, void *params, gsl_matrix *J)
 int gsl_multifit_callback_fdf(const gsl_vector *X, void *params, 
 			      gsl_vector *F, gsl_matrix *J)
 {
-  int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT;
+  int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT;
   struct callback_params *parms=params;
   value x_barr, f_barr, j_barr;
   size_t p = X->size;

--- a/src/mlgsl_fun.c
+++ b/src/mlgsl_fun.c
@@ -103,7 +103,7 @@ int gsl_multiroot_callback(const gsl_vector *x, void *params, gsl_vector *F)
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  callback2(p->closure, x_barr, f_barr);
+  caml_callback2(p->closure, x_barr, f_barr);
   gsl_vector_memcpy(F, &f_v.vector);
   return GSL_SUCCESS;
 }
@@ -122,7 +122,7 @@ int gsl_multiroot_callback_f(const gsl_vector *x, void *params, gsl_vector *F)
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  callback2(Field(p->closure, 0), x_barr, f_barr);
+  caml_callback2(Field(p->closure, 0), x_barr, f_barr);
   gsl_vector_memcpy(F, &f_v.vector);
   return GSL_SUCCESS;
 }
@@ -142,7 +142,7 @@ int gsl_multiroot_callback_df(const gsl_vector *x, void *params, gsl_matrix *J)
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), len, len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  callback2(Field(p->closure, 1), x_barr, j_barr);
+  caml_callback2(Field(p->closure, 1), x_barr, j_barr);
   gsl_matrix_memcpy(J, &j_v.matrix);
   return GSL_SUCCESS;
 }
@@ -165,7 +165,7 @@ int gsl_multiroot_callback_fdf(const gsl_vector *x, void *params,
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), len, len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  callback3(Field(p->closure, 2), x_barr, f_barr, j_barr);
+  caml_callback3(Field(p->closure, 2), x_barr, f_barr, j_barr);
   gsl_vector_memcpy(F, &f_v.vector);
   gsl_matrix_memcpy(J, &j_v.matrix);
   return GSL_SUCCESS;
@@ -187,7 +187,7 @@ double gsl_multimin_callback(const gsl_vector *x, void *params)
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  res=callback(p->closure, x_barr);
+  res=caml_callback(p->closure, x_barr);
   return Double_val(res);
 }
 
@@ -204,7 +204,7 @@ double gsl_multimin_callback_f(const gsl_vector *x, void *params)
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  res=callback(Field(p->closure, 0), x_barr);
+  res=caml_callback(Field(p->closure, 0), x_barr);
   return Double_val(res);
 }
 
@@ -222,7 +222,7 @@ void gsl_multimin_callback_df(const gsl_vector *x, void *params, gsl_vector *G)
   g_v = gsl_vector_view_array(Caml_ba_data_val(g_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  callback2(Field(p->closure, 1), x_barr, g_barr);
+  caml_callback2(Field(p->closure, 1), x_barr, g_barr);
   gsl_vector_memcpy(G, &g_v.vector);
 }
 
@@ -242,7 +242,7 @@ void gsl_multimin_callback_fdf(const gsl_vector *x, void *params,
   g_v = gsl_vector_view_array(Caml_ba_data_val(g_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
-  res=callback2(Field(p->closure, 2), x_barr, g_barr);
+  res=caml_callback2(Field(p->closure, 2), x_barr, g_barr);
   gsl_vector_memcpy(G, &g_v.vector);
   *f=Double_val(res);
 }
@@ -265,7 +265,7 @@ int gsl_multifit_callback_f(const gsl_vector *X, void *params, gsl_vector *F)
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), n);
 
   gsl_vector_memcpy(&x_v.vector, X);
-  callback2(Field(parms->closure, 0), x_barr, f_barr);
+  caml_callback2(Field(parms->closure, 0), x_barr, f_barr);
   gsl_vector_memcpy(F, &f_v.vector);
   return GSL_SUCCESS;
 }
@@ -287,7 +287,7 @@ int gsl_multifit_callback_df(const gsl_vector *X, void *params, gsl_matrix *J)
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), n, p);
 
   gsl_vector_memcpy(&x_v.vector, X);
-  res=callback2(Field(parms->closure, 1), x_barr, j_barr);
+  res=caml_callback2(Field(parms->closure, 1), x_barr, j_barr);
   if(Is_exception_result(res))
     return GSL_FAILURE;
   gsl_matrix_memcpy(J, &j_v.matrix);
@@ -313,7 +313,7 @@ int gsl_multifit_callback_fdf(const gsl_vector *X, void *params,
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), n, p);
 
   gsl_vector_memcpy(&x_v.vector, X);
-  callback3(Field(parms->closure, 2), x_barr, f_barr, j_barr);
+  caml_callback3(Field(parms->closure, 2), x_barr, f_barr, j_barr);
   gsl_vector_memcpy(F, &f_v.vector);
   gsl_matrix_memcpy(J, &j_v.matrix);
   return GSL_SUCCESS;

--- a/src/mlgsl_fun.c
+++ b/src/mlgsl_fun.c
@@ -22,7 +22,7 @@ double gslfun_callback(double x, void *params)
   struct callback_params *p=params;
   value res;
   value v_x = caml_copy_double(x);
-  res=callback(p->closure, v_x);
+  res=caml_callback(p->closure, v_x);
   return Double_val(res);
 }
 
@@ -32,7 +32,7 @@ double gslfun_callback_indir(double x, void *params)
   value res;
   value v_x = caml_copy_double(x);
   value *closure = params;
-  res=callback(*closure, v_x);
+  res=caml_callback(*closure, v_x);
   return Double_val(res);
 }
  
@@ -41,7 +41,7 @@ double gslfun_callback_f(double x, void *params)
   struct callback_params *p=params;
   value res;
   value v_x=caml_copy_double(x);
-  res=callback(Field(p->closure, 0), v_x);
+  res=caml_callback(Field(p->closure, 0), v_x);
   return Double_val(res);
 }
 
@@ -50,7 +50,7 @@ double gslfun_callback_df(double x, void *params)
   struct callback_params *p=params;
   value res;
   value v_x=caml_copy_double(x);
-  res=callback(Field(p->closure, 1), v_x);
+  res=caml_callback(Field(p->closure, 1), v_x);
   return Double_val(res);
 }
 
@@ -60,7 +60,7 @@ void gslfun_callback_fdf(double x, void *params,
   struct callback_params *p=params;
   value res;
   value v_x=caml_copy_double(x);
-  res=callback(Field(p->closure, 2), v_x);
+  res=caml_callback(Field(p->closure, 2), v_x);
   *f =Double_val(Field(res, 0));
   *df=Double_val(Field(res, 1));
 }
@@ -73,7 +73,7 @@ double gsl_monte_callback(double *x_arr, size_t dim, void *params)
   value res;
 
   memcpy(Double_array_val(p->dbl), x_arr, dim*sizeof(double));
-  res=callback(p->closure, p->dbl);
+  res=caml_callback(p->closure, p->dbl);
   return Double_val(res);
 }
 
@@ -82,7 +82,7 @@ double gsl_monte_callback_fast(double *x_arr, size_t dim, void *params)
   struct callback_params *p=params;
   value res;
 
-  res=callback(p->closure, (value)x_arr);
+  res=caml_callback(p->closure, (value)x_arr);
   return Double_val(res);
 }
 

--- a/src/mlgsl_fun.c
+++ b/src/mlgsl_fun.c
@@ -99,8 +99,8 @@ int gsl_multiroot_callback(const gsl_vector *x, void *params, gsl_vector *F)
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
   f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
-  f_v = gsl_vector_view_array(Data_bigarray_val(f_barr), len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
+  f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   callback2(p->closure, x_barr, f_barr);
@@ -118,8 +118,8 @@ int gsl_multiroot_callback_f(const gsl_vector *x, void *params, gsl_vector *F)
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
   f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
-  f_v = gsl_vector_view_array(Data_bigarray_val(f_barr), len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
+  f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   callback2(Field(p->closure, 0), x_barr, f_barr);
@@ -138,8 +138,8 @@ int gsl_multiroot_callback_df(const gsl_vector *x, void *params, gsl_matrix *J)
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
   j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, len, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
-  j_v = gsl_matrix_view_array(Data_bigarray_val(j_barr), len, len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
+  j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), len, len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   callback2(Field(p->closure, 1), x_barr, j_barr);
@@ -160,9 +160,9 @@ int gsl_multiroot_callback_fdf(const gsl_vector *x, void *params,
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
   f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
   j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, len, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
-  f_v = gsl_vector_view_array(Data_bigarray_val(f_barr), len);
-  j_v = gsl_matrix_view_array(Data_bigarray_val(j_barr), len, len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
+  f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
+  j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), len, len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   callback3(Field(p->closure, 2), x_barr, f_barr, j_barr);
@@ -184,7 +184,7 @@ double gsl_multimin_callback(const gsl_vector *x, void *params)
   value res;
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   res=callback(p->closure, x_barr);
@@ -201,7 +201,7 @@ double gsl_multimin_callback_f(const gsl_vector *x, void *params)
   value res;
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   res=callback(Field(p->closure, 0), x_barr);
@@ -218,8 +218,8 @@ void gsl_multimin_callback_df(const gsl_vector *x, void *params, gsl_vector *G)
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
   g_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
-  g_v = gsl_vector_view_array(Data_bigarray_val(g_barr), len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
+  g_v = gsl_vector_view_array(Caml_ba_data_val(g_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   callback2(Field(p->closure, 1), x_barr, g_barr);
@@ -238,8 +238,8 @@ void gsl_multimin_callback_fdf(const gsl_vector *x, void *params,
   
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
   g_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), len);
-  g_v = gsl_vector_view_array(Data_bigarray_val(g_barr), len);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
+  g_v = gsl_vector_view_array(Caml_ba_data_val(g_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
   res=callback2(Field(p->closure, 2), x_barr, g_barr);
@@ -261,8 +261,8 @@ int gsl_multifit_callback_f(const gsl_vector *X, void *params, gsl_vector *F)
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, p);
   f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, n);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), p);
-  f_v = gsl_vector_view_array(Data_bigarray_val(f_barr), n);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), p);
+  f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), n);
 
   gsl_vector_memcpy(&x_v.vector, X);
   callback2(Field(parms->closure, 0), x_barr, f_barr);
@@ -283,8 +283,8 @@ int gsl_multifit_callback_df(const gsl_vector *X, void *params, gsl_matrix *J)
 
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, p);
   j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, n, p);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), p);
-  j_v = gsl_matrix_view_array(Data_bigarray_val(j_barr), n, p);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), p);
+  j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), n, p);
 
   gsl_vector_memcpy(&x_v.vector, X);
   res=callback2(Field(parms->closure, 1), x_barr, j_barr);
@@ -308,9 +308,9 @@ int gsl_multifit_callback_fdf(const gsl_vector *X, void *params,
   x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, p);
   f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, n);
   j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, n, p);
-  x_v = gsl_vector_view_array(Data_bigarray_val(x_barr), p);
-  f_v = gsl_vector_view_array(Data_bigarray_val(f_barr), n);
-  j_v = gsl_matrix_view_array(Data_bigarray_val(j_barr), n, p);
+  x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), p);
+  f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), n);
+  j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), n, p);
 
   gsl_vector_memcpy(&x_v.vector, X);
   callback3(Field(parms->closure, 2), x_barr, f_barr, j_barr);

--- a/src/mlgsl_fun.c
+++ b/src/mlgsl_fun.c
@@ -21,7 +21,7 @@ double gslfun_callback(double x, void *params)
 {
   struct callback_params *p=params;
   value res;
-  value v_x = copy_double(x);
+  value v_x = caml_copy_double(x);
   res=callback(p->closure, v_x);
   return Double_val(res);
 }
@@ -30,7 +30,7 @@ double gslfun_callback(double x, void *params)
 double gslfun_callback_indir(double x, void *params)
 {
   value res;
-  value v_x = copy_double(x);
+  value v_x = caml_copy_double(x);
   value *closure = params;
   res=callback(*closure, v_x);
   return Double_val(res);
@@ -40,7 +40,7 @@ double gslfun_callback_f(double x, void *params)
 {
   struct callback_params *p=params;
   value res;
-  value v_x=copy_double(x);
+  value v_x=caml_copy_double(x);
   res=callback(Field(p->closure, 0), v_x);
   return Double_val(res);
 }
@@ -49,7 +49,7 @@ double gslfun_callback_df(double x, void *params)
 {
   struct callback_params *p=params;
   value res;
-  value v_x=copy_double(x);
+  value v_x=caml_copy_double(x);
   res=callback(Field(p->closure, 1), v_x);
   return Double_val(res);
 }
@@ -59,7 +59,7 @@ void gslfun_callback_fdf(double x, void *params,
 {
   struct callback_params *p=params;
   value res;
-  value v_x=copy_double(x);
+  value v_x=caml_copy_double(x);
   res=callback(Field(p->closure, 2), v_x);
   *f =Double_val(Field(res, 0));
   *df=Double_val(Field(res, 1));

--- a/src/mlgsl_fun.c
+++ b/src/mlgsl_fun.c
@@ -97,8 +97,8 @@ int gsl_multiroot_callback(const gsl_vector *x, void *params, gsl_vector *F)
   int len = x->size;
   gsl_vector_view x_v, f_v;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
+  f_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
 
@@ -116,8 +116,8 @@ int gsl_multiroot_callback_f(const gsl_vector *x, void *params, gsl_vector *F)
   int len = x->size;
   gsl_vector_view x_v, f_v;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
+  f_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
 
@@ -136,8 +136,8 @@ int gsl_multiroot_callback_df(const gsl_vector *x, void *params, gsl_matrix *J)
   gsl_vector_view x_v;
   gsl_matrix_view j_v;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, len, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
+  j_barr = caml_ba_alloc_dims(barr_flags, 2, NULL, len, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), len, len);
 
@@ -157,9 +157,9 @@ int gsl_multiroot_callback_fdf(const gsl_vector *x, void *params,
   gsl_vector_view x_v, f_v;
   gsl_matrix_view j_v;
   
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, len, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
+  f_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
+  j_barr = caml_ba_alloc_dims(barr_flags, 2, NULL, len, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), len);
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), len, len);
@@ -183,7 +183,7 @@ double gsl_multimin_callback(const gsl_vector *x, void *params)
   gsl_vector_view x_v;
   value res;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
@@ -200,7 +200,7 @@ double gsl_multimin_callback_f(const gsl_vector *x, void *params)
   gsl_vector_view x_v;
   value res;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
 
   gsl_vector_memcpy(&x_v.vector, x);
@@ -216,8 +216,8 @@ void gsl_multimin_callback_df(const gsl_vector *x, void *params, gsl_vector *G)
   int len = x->size;
   gsl_vector_view x_v, g_v;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  g_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
+  g_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
   g_v = gsl_vector_view_array(Caml_ba_data_val(g_barr), len);
 
@@ -236,8 +236,8 @@ void gsl_multimin_callback_fdf(const gsl_vector *x, void *params,
   gsl_vector_view x_v, g_v;
   value res;
   
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
-  g_barr = alloc_bigarray_dims(barr_flags, 1, NULL, len);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
+  g_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, len);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), len);
   g_v = gsl_vector_view_array(Caml_ba_data_val(g_barr), len);
 
@@ -259,8 +259,8 @@ int gsl_multifit_callback_f(const gsl_vector *X, void *params, gsl_vector *F)
   size_t n = F->size;
   gsl_vector_view x_v, f_v;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, p);
-  f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, n);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, p);
+  f_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, n);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), p);
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), n);
 
@@ -281,8 +281,8 @@ int gsl_multifit_callback_df(const gsl_vector *X, void *params, gsl_matrix *J)
   gsl_matrix_view j_v;
   value res;
 
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, p);
-  j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, n, p);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, p);
+  j_barr = caml_ba_alloc_dims(barr_flags, 2, NULL, n, p);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), p);
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), n, p);
 
@@ -305,9 +305,9 @@ int gsl_multifit_callback_fdf(const gsl_vector *X, void *params,
   gsl_vector_view x_v, f_v;
   gsl_matrix_view j_v;
   
-  x_barr = alloc_bigarray_dims(barr_flags, 1, NULL, p);
-  f_barr = alloc_bigarray_dims(barr_flags, 1, NULL, n);
-  j_barr = alloc_bigarray_dims(barr_flags, 2, NULL, n, p);
+  x_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, p);
+  f_barr = caml_ba_alloc_dims(barr_flags, 1, NULL, n);
+  j_barr = caml_ba_alloc_dims(barr_flags, 2, NULL, n, p);
   x_v = gsl_vector_view_array(Caml_ba_data_val(x_barr), p);
   f_v = gsl_vector_view_array(Caml_ba_data_val(f_barr), n);
   j_v = gsl_matrix_view_array(Caml_ba_data_val(j_barr), n, p);

--- a/src/mlgsl_histo.c
+++ b/src/mlgsl_histo.c
@@ -60,7 +60,7 @@ CAMLprim value ml_gsl_histogram_max_val(value vh)
 {
   gsl_histogram h;
   histo_of_val(&h, vh);
-  return copy_double(gsl_histogram_max_val(&h));
+  return caml_copy_double(gsl_histogram_max_val(&h));
 }
 
 CAMLprim value ml_gsl_histogram_max_bin(value vh)
@@ -74,7 +74,7 @@ CAMLprim value ml_gsl_histogram_min_val(value vh)
 {
   gsl_histogram h;
   histo_of_val(&h, vh);
-  return copy_double(gsl_histogram_min_val(&h));
+  return caml_copy_double(gsl_histogram_min_val(&h));
 }
 
 CAMLprim value ml_gsl_histogram_min_bin(value vh)
@@ -88,21 +88,21 @@ CAMLprim value ml_gsl_histogram_mean(value vh)
 {
   gsl_histogram h;
   histo_of_val(&h, vh);
-  return copy_double(gsl_histogram_mean(&h));
+  return caml_copy_double(gsl_histogram_mean(&h));
 }
 
 CAMLprim value ml_gsl_histogram_sigma(value vh)
 {
   gsl_histogram h;
   histo_of_val(&h, vh);
-  return copy_double(gsl_histogram_sigma(&h));
+  return caml_copy_double(gsl_histogram_sigma(&h));
 }
 
 CAMLprim value ml_gsl_histogram_sum(value vh)
 {
   gsl_histogram h;
   histo_of_val(&h, vh);
-  return copy_double(gsl_histogram_sum(&h));
+  return caml_copy_double(gsl_histogram_sum(&h));
 }
 
 CAMLprim value ml_gsl_histogram_equal_bins_p(value vh1, value vh2)
@@ -186,5 +186,5 @@ CAMLprim value ml_gsl_histogram_pdf_sample(value vp, value r)
 {
   gsl_histogram_pdf p;
   histopdf_of_val(&p, vp);
-  return copy_double(gsl_histogram_pdf_sample(&p, r));
+  return caml_copy_double(gsl_histogram_pdf_sample(&p, r));
 }

--- a/src/mlgsl_ieee.c
+++ b/src/mlgsl_ieee.c
@@ -50,7 +50,7 @@ CAMLprim value ml_gsl_ieee_set_mode(value oprecision, value orounding, value ex_
     GSL_IEEE_MASK_DENORMALIZED, GSL_IEEE_MASK_OVERFLOW,
     GSL_IEEE_MASK_UNDERFLOW, GSL_IEEE_MASK_ALL,
     GSL_IEEE_TRAP_INEXACT } ;
-  int mask = convert_flag_list(ex_list, mask_conv);
+  int mask = caml_convert_flag_list(ex_list, mask_conv);
 
 #define Lookup_precision(v) precision_conv[ Int_val(v) ]
 #define Lookup_round(v)     round_conv[ Int_val(v) ]
@@ -99,7 +99,7 @@ static int except_conv [] = {
 
 static int conv_excepts(value e)
 {
-  return convert_flag_list(e, except_conv);
+  return caml_convert_flag_list(e, except_conv);
 }
 
 static value rev_conv_excepts(int e)

--- a/src/mlgsl_ieee.c
+++ b/src/mlgsl_ieee.c
@@ -15,7 +15,7 @@ static value rep_val(const gsl_ieee_double_rep *r)
 {
   CAMLparam0();
   CAMLlocal2(v, m);
-  m=copy_string(r->mantissa);
+  m=caml_copy_string(r->mantissa);
   v=caml_alloc_small(4, 0);
   Field(v, 0)= Val_int(r->sign);
   Field(v, 1)= m;

--- a/src/mlgsl_ieee.c
+++ b/src/mlgsl_ieee.c
@@ -16,7 +16,7 @@ static value rep_val(const gsl_ieee_double_rep *r)
   CAMLparam0();
   CAMLlocal2(v, m);
   m=copy_string(r->mantissa);
-  v=alloc_small(4, 0);
+  v=caml_alloc_small(4, 0);
   Field(v, 0)= Val_int(r->sign);
   Field(v, 1)= m;
   Field(v, 2)= Val_int(r->exponent);
@@ -111,7 +111,7 @@ static value rev_conv_excepts(int e)
   
   for(i = tab_size-2; i >= 0 ; i--)
     if(except_conv[i] & e) {
-      c = alloc_small(2, Tag_cons);
+      c = caml_alloc_small(2, Tag_cons);
       Field(c, 0) = Val_int(i);
       Field(c, 1) = v;
       v = c;

--- a/src/mlgsl_integration.c
+++ b/src/mlgsl_integration.c
@@ -30,7 +30,7 @@ CAMLprim value ml_gsl_integration_qng(value fun, value a, value b,
 		      &result, &abserr, &neval);
   r = caml_copy_double(result);
   e = caml_copy_double(abserr);
-  res = alloc_small(3, 0);
+  res = caml_alloc_small(3, 0);
   Field(res, 0) = r;
   Field(res, 1) = e;
   Field(res, 2) = Val_int(neval);

--- a/src/mlgsl_integration.c
+++ b/src/mlgsl_integration.c
@@ -28,8 +28,8 @@ CAMLprim value ml_gsl_integration_qng(value fun, value a, value b,
   gsl_integration_qng(&gf, Double_val(a), Double_val(b),
 		      Double_val(epsabs), Double_val(epsrel),
 		      &result, &abserr, &neval);
-  r = copy_double(result);
-  e = copy_double(abserr);
+  r = caml_copy_double(result);
+  e = caml_copy_double(abserr);
   res = alloc_small(3, 0);
   Field(res, 0) = r;
   Field(res, 1) = e;

--- a/src/mlgsl_integration.c
+++ b/src/mlgsl_integration.c
@@ -67,7 +67,7 @@ CAMLprim value ml_gsl_integration_qag(value fun, value a, value b,
   int c_key = key_conv [ Int_val(key) ];
   gsl_integration_workspace *gslws = GSL_WS(ws);
 
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qag(&gf, 
 		      Double_val(a), Double_val(b), 
 		      Double_val(epsabs), Double_val(epsrel),
@@ -91,7 +91,7 @@ CAMLprim value ml_gsl_integration_qags(value fun, value a, value b,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
 
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qags(&gf,
 		       Double_val(a), Double_val(b), 
 		       Double_val(epsabs), Double_val(epsrel),
@@ -116,7 +116,7 @@ CAMLprim value ml_gsl_integration_qagp(value fun, value pts,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qagp(&gf, 
 		       Double_array_val(pts), Double_array_length(pts),
 		       Double_val(epsabs), Double_val(epsrel),
@@ -140,7 +140,7 @@ CAMLprim value ml_gsl_integration_qagi(value fun,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val,gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val,gslws->limit);
   gsl_integration_qagi(&gf,
 		       Double_val(epsabs), Double_val(epsrel),
 		       c_limit, gslws, &result, &abserr);
@@ -157,7 +157,7 @@ CAMLprim value ml_gsl_integration_qagiu(value fun, value a,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qagiu(&gf, Double_val(a),
 			Double_val(epsabs), Double_val(epsrel),
 			c_limit, gslws, &result, &abserr);
@@ -181,7 +181,7 @@ CAMLprim value ml_gsl_integration_qagil(value fun, value b,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qagil(&gf, Double_val(b),
 			Double_val(epsabs), Double_val(epsrel),
 			c_limit, gslws, &result, &abserr);
@@ -208,7 +208,7 @@ CAMLprim value ml_gsl_integration_qawc(value fun, value a, value b, value c,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qawc(&gf,
 		       Double_val(a), Double_val(b), Double_val(c),
 		       Double_val(epsabs), Double_val(epsrel),
@@ -250,7 +250,7 @@ CAMLprim value ml_gsl_integration_qaws(value fun, value a, value b, value table 
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qaws(&gf, 
 		       Double_val(a), Double_val(b), QAWSTABLE_VAL(table),
 		       Double_val(epsabs), Double_val(epsrel),
@@ -299,7 +299,7 @@ CAMLprim value ml_gsl_integration_qawo(value fun, value a,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qawo(&gf, Double_val(a), 
 		       Double_val(epsabs), Double_val(epsrel),
 		       c_limit, gslws, 
@@ -324,7 +324,7 @@ CAMLprim value ml_gsl_integration_qawf(value fun, value a, value epsabs,
   size_t c_limit;
   gsl_integration_workspace *gslws = GSL_WS(ws);
   
-  c_limit = Opt_arg(limit, Int_val, gslws->limit);
+  c_limit = Opt_arg(limit, (size_t)Int_val, gslws->limit);
   gsl_integration_qawf(&gf, Double_val(a), 
 		       Double_val(epsabs), c_limit, 
 		       gslws, GSL_WS(cyclews),

--- a/src/mlgsl_interp.c
+++ b/src/mlgsl_interp.c
@@ -70,7 +70,7 @@ CAMLprim value ml_gsl_interp_accel_free(value ia)
 
 CAMLprim value ml_gsl_interp_eval(value i, value xa, value ya, value x, value A)
 {
-  return copy_double(gsl_interp_eval(Interp_val(i),
+  return caml_copy_double(gsl_interp_eval(Interp_val(i),
 				     Double_array_val(xa),
 				     Double_array_val(ya),
 				     Double_val(x),
@@ -80,7 +80,7 @@ CAMLprim value ml_gsl_interp_eval(value i, value xa, value ya, value x, value A)
 CAMLprim value ml_gsl_interp_eval_deriv(value i, value xa, value ya, 
 					value x, value A)
 {
-  return copy_double(gsl_interp_eval_deriv(Interp_val(i),
+  return caml_copy_double(gsl_interp_eval_deriv(Interp_val(i),
 					   Double_array_val(xa),
 					   Double_array_val(ya),
 					   Double_val(x),
@@ -90,7 +90,7 @@ CAMLprim value ml_gsl_interp_eval_deriv(value i, value xa, value ya,
 CAMLprim value ml_gsl_interp_eval_deriv2(value i, value xa, value ya, 
 					 value x, value A)
 {
-  return copy_double(gsl_interp_eval_deriv2(Interp_val(i),
+  return caml_copy_double(gsl_interp_eval_deriv2(Interp_val(i),
 					    Double_array_val(xa),
 					    Double_array_val(ya),
 					    Double_val(x),
@@ -100,7 +100,7 @@ CAMLprim value ml_gsl_interp_eval_deriv2(value i, value xa, value ya,
 CAMLprim value ml_gsl_interp_eval_integ(value i, value xa, value ya, 
 					value a, value b, value A)
 {
-  return copy_double(gsl_interp_eval_integ(Interp_val(i),
+  return caml_copy_double(gsl_interp_eval_integ(Interp_val(i),
 					   Double_array_val(xa),
 					   Double_array_val(ya),
 					   Double_val(a), Double_val(b),

--- a/src/mlgsl_interp.c
+++ b/src/mlgsl_interp.c
@@ -47,7 +47,7 @@ CAMLprim value ml_gsl_interp_init(value i, value x, value y, value size)
 
 CAMLprim value ml_gsl_interp_name(value i)
 {
-  return copy_string(gsl_interp_name(Interp_val(i)));
+  return caml_copy_string(gsl_interp_name(Interp_val(i)));
 }
 
 CAMLprim value ml_gsl_interp_min_size(value i)

--- a/src/mlgsl_linalg.c
+++ b/src/mlgsl_linalg.c
@@ -90,14 +90,14 @@ CAMLprim value ml_gsl_linalg_LU_det(value LU, value sig)
 {
   _DECLARE_MATRIX(LU);
   _CONVERT_MATRIX(LU);
-  return copy_double(gsl_linalg_LU_det(&m_LU, Int_val(sig)));
+  return caml_copy_double(gsl_linalg_LU_det(&m_LU, Int_val(sig)));
 }
 
 CAMLprim value ml_gsl_linalg_LU_lndet(value LU)
 {
   _DECLARE_MATRIX(LU);
   _CONVERT_MATRIX(LU);
-  return copy_double(gsl_linalg_LU_lndet(&m_LU));
+  return caml_copy_double(gsl_linalg_LU_lndet(&m_LU));
 }
 
 CAMLprim value ml_gsl_linalg_LU_sgndet(value LU, value sig)

--- a/src/mlgsl_linalg_complex.c
+++ b/src/mlgsl_linalg_complex.c
@@ -85,7 +85,7 @@ CAMLprim value ml_gsl_linalg_complex_LU_lndet(value LU)
 {
   _DECLARE_MATRIX(LU);
   _CONVERT_MATRIX(LU);
-  return copy_double(gsl_linalg_complex_LU_lndet(&m_LU));
+  return caml_copy_double(gsl_linalg_complex_LU_lndet(&m_LU));
 }
 
 CAMLprim value ml_gsl_linalg_complex_LU_sgndet(value LU, value sig)

--- a/src/mlgsl_math.c
+++ b/src/mlgsl_math.c
@@ -8,11 +8,11 @@
 #include "wrappers.h"
 
 
-ML1(gsl_log1p, Double_val, copy_double)
-ML1(gsl_expm1, Double_val, copy_double)
-ML2(gsl_hypot, Double_val, Double_val, copy_double)
-ML1(gsl_acosh, Double_val, copy_double)
-ML1(gsl_asinh, Double_val, copy_double)
-ML1(gsl_atanh, Double_val, copy_double)
+ML1(gsl_log1p, Double_val, caml_copy_double)
+ML1(gsl_expm1, Double_val, caml_copy_double)
+ML2(gsl_hypot, Double_val, Double_val, caml_copy_double)
+ML1(gsl_acosh, Double_val, caml_copy_double)
+ML1(gsl_asinh, Double_val, caml_copy_double)
+ML1(gsl_atanh, Double_val, caml_copy_double)
 
 ML3(gsl_fcmp, Double_val, Double_val, Double_val, Val_int)

--- a/src/mlgsl_matrix.h
+++ b/src/mlgsl_matrix.h
@@ -14,7 +14,7 @@
 
 static inline void TYPE(mlgsl_mat_of_bigarray)(TYPE(gsl_matrix) *cmat, 
 					       value vmat){
-  struct caml_bigarray *bigarr = Caml_ba_array_val(vmat);
+  struct caml_ba_array *bigarr = Caml_ba_array_val(vmat);
   cmat->block = NULL;
   cmat->owner = 0;
   cmat->size1 = bigarr->dim[0];

--- a/src/mlgsl_matrix.h
+++ b/src/mlgsl_matrix.h
@@ -14,7 +14,7 @@
 
 static inline void TYPE(mlgsl_mat_of_bigarray)(TYPE(gsl_matrix) *cmat, 
 					       value vmat){
-  struct caml_bigarray *bigarr = Bigarray_val(vmat);
+  struct caml_bigarray *bigarr = Caml_ba_array_val(vmat);
   cmat->block = NULL;
   cmat->owner = 0;
   cmat->size1 = bigarr->dim[0];

--- a/src/mlgsl_min.c
+++ b/src/mlgsl_min.c
@@ -63,7 +63,7 @@ ML1(gsl_min_fminimizer_name, Minimizer_val, copy_string)
 
 ML1(gsl_min_fminimizer_iterate, Minimizer_val, Unit)
 
-ML1(gsl_min_fminimizer_x_minimum, Minimizer_val, copy_double)
+ML1(gsl_min_fminimizer_x_minimum, Minimizer_val, caml_copy_double)
 
 CAMLprim value ml_gsl_min_fminimizer_x_interv(value S)
 {

--- a/src/mlgsl_min.c
+++ b/src/mlgsl_min.c
@@ -27,7 +27,7 @@ CAMLprim value ml_gsl_min_fminimizer_alloc(value t)
   gsl_min_fminimizer *s;
 
   s=gsl_min_fminimizer_alloc(Minimizertype_val(t));
-  params=stat_alloc(sizeof *params);
+  params=caml_stat_alloc(sizeof *params);
   
   res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)s;
@@ -54,7 +54,7 @@ CAMLprim value ml_gsl_min_fminimizer_set(value s, value f, value min, value lo, 
 CAMLprim value ml_gsl_min_fminimizer_free(value s)
 {
   remove_global_root(&(Mparams_val(s)->closure));
-  stat_free(Mparams_val(s));
+  caml_stat_free(Mparams_val(s));
   gsl_min_fminimizer_free(Minimizer_val(s));
   return Val_unit;
 }

--- a/src/mlgsl_min.c
+++ b/src/mlgsl_min.c
@@ -36,7 +36,7 @@ CAMLprim value ml_gsl_min_fminimizer_alloc(value t)
   params->gslfun.gf.params   = params;
   params->closure = Val_unit;
   params->dbl     = Val_unit;
-  register_global_root(&(params->closure));
+  caml_register_global_root(&(params->closure));
   CAMLreturn(res);
 }
 #define Minimizer_val(v) ((gsl_min_fminimizer *)Field((v), 0))
@@ -53,7 +53,7 @@ CAMLprim value ml_gsl_min_fminimizer_set(value s, value f, value min, value lo, 
 
 CAMLprim value ml_gsl_min_fminimizer_free(value s)
 {
-  remove_global_root(&(Mparams_val(s)->closure));
+  caml_remove_global_root(&(Mparams_val(s)->closure));
   caml_stat_free(Mparams_val(s));
   gsl_min_fminimizer_free(Minimizer_val(s));
   return Val_unit;

--- a/src/mlgsl_min.c
+++ b/src/mlgsl_min.c
@@ -29,7 +29,7 @@ CAMLprim value ml_gsl_min_fminimizer_alloc(value t)
   s=gsl_min_fminimizer_alloc(Minimizertype_val(t));
   params=stat_alloc(sizeof *params);
   
-  res=alloc_small(2, Abstract_tag);
+  res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)s;
   Field(res, 1) = (value)params;
   params->gslfun.gf.function = &gslfun_callback ;

--- a/src/mlgsl_min.c
+++ b/src/mlgsl_min.c
@@ -59,7 +59,7 @@ CAMLprim value ml_gsl_min_fminimizer_free(value s)
   return Val_unit;
 }
 
-ML1(gsl_min_fminimizer_name, Minimizer_val, copy_string)
+ML1(gsl_min_fminimizer_name, Minimizer_val, caml_copy_string)
 
 ML1(gsl_min_fminimizer_iterate, Minimizer_val, Unit)
 

--- a/src/mlgsl_monte.c
+++ b/src/mlgsl_monte.c
@@ -56,7 +56,7 @@ CAMLprim value ml_gsl_monte_plain_alloc(value d)
     params->gslfun.mf.dim = dim;
     params->gslfun.mf.params = params;
     params->closure = Val_unit;
-    params->dbl = alloc(dim * Double_wosize, Double_array_tag);
+    params->dbl = caml_alloc(dim * Double_wosize, Double_array_tag);
   
     register_global_root(&(params->closure));
     register_global_root(&(params->dbl));
@@ -131,7 +131,7 @@ CAMLprim value ml_gsl_monte_miser_alloc(value d)
     params->gslfun.mf.dim = dim;
     params->gslfun.mf.params = params;
     params->closure = Val_unit;
-    params->dbl = alloc(dim * Double_wosize, Double_array_tag);
+    params->dbl = caml_alloc(dim * Double_wosize, Double_array_tag);
   
     register_global_root(&(params->closure));
     register_global_root(&(params->dbl));
@@ -187,7 +187,7 @@ CAMLprim value ml_gsl_monte_miser_get_params(value state)
   CAMLparam0();
   CAMLlocal1(r);
   gsl_monte_miser_state *s = GSLMISERSTATE_VAL(state);
-  r=alloc_tuple(5);
+  r=caml_alloc_tuple(5);
   Store_field(r, 0, caml_copy_double(s->estimate_frac));
   Store_field(r, 1, Val_int(s->min_calls));
   Store_field(r, 2, Val_int(s->min_calls_per_bisection));
@@ -233,7 +233,7 @@ CAMLprim value ml_gsl_monte_vegas_alloc(value d)
     params->gslfun.mf.dim = dim;
     params->gslfun.mf.params = params;
     params->closure = Val_unit;
-    params->dbl = alloc(dim * Double_wosize, Double_array_tag);
+    params->dbl = caml_alloc(dim * Double_wosize, Double_array_tag);
     
     register_global_root(&(params->closure));
     register_global_root(&(params->dbl));
@@ -305,7 +305,7 @@ CAMLprim value ml_gsl_monte_vegas_get_params(value state)
   CAMLparam0(); 
   CAMLlocal1(r);
   gsl_monte_vegas_state *s = GSLVEGASSTATE_VAL(state);
-  r=alloc_tuple(6);
+  r=caml_alloc_tuple(6);
   Store_field(r, 0, caml_copy_double(s->alpha));
   Store_field(r, 1, Val_int(s->iterations));
   Store_field(r, 2, Val_int(s->stage));

--- a/src/mlgsl_monte.c
+++ b/src/mlgsl_monte.c
@@ -237,7 +237,7 @@ CAMLprim value ml_gsl_monte_vegas_alloc(value d)
     
     caml_register_global_root(&(params->closure));
     caml_register_global_root(&(params->dbl));
-    caml_register_global_root(&(Field(res, 2)));
+    caml_register_global_root((value*)&Field(res, 2));
     CAMLreturn(res);
   }
 }
@@ -252,7 +252,7 @@ CAMLprim value ml_gsl_monte_vegas_free(value state)
   caml_stat_free(CallbackParams_val(state));
   if(s->ostream != stdout && s->ostream != stderr)
     fclose(s->ostream);
-  caml_remove_global_root(&GSLVEGASSTREAM_VAL(state));
+  caml_remove_global_root((value*)&GSLVEGASSTREAM_VAL(state));
   gsl_monte_vegas_free(s);
   return Val_unit;
 }

--- a/src/mlgsl_monte.c
+++ b/src/mlgsl_monte.c
@@ -49,7 +49,7 @@ CAMLprim value ml_gsl_monte_plain_alloc(value d)
     CAMLparam0();
     CAMLlocal1(res);
 
-    res=alloc_small(2, Abstract_tag);
+    res=caml_alloc_small(2, Abstract_tag);
     Field(res, 0) = (value)s;
     Field(res, 1) = (value)params;
     params->gslfun.mf.f = &gsl_monte_callback;
@@ -124,7 +124,7 @@ CAMLprim value ml_gsl_monte_miser_alloc(value d)
   {
     CAMLparam0();
     CAMLlocal1(res);
-    res=alloc_small(2, Abstract_tag);
+    res=caml_alloc_small(2, Abstract_tag);
     Field(res, 0) = (value)s;
     Field(res, 1) = (value)params;
     params->gslfun.mf.f = &gsl_monte_callback;
@@ -225,7 +225,7 @@ CAMLprim value ml_gsl_monte_vegas_alloc(value d)
   {
     CAMLparam0();
     CAMLlocal1(res);    
-    res=alloc_small(3, Abstract_tag);
+    res=caml_alloc_small(3, Abstract_tag);
     Field(res, 0) = (value)s;
     Field(res, 1) = (value)params;
     Field(res, 2) = Val_none;
@@ -293,7 +293,7 @@ CAMLprim value ml_gsl_monte_vegas_get_info(value state)
 {
   value r;
   gsl_monte_vegas_state *s = GSLVEGASSTATE_VAL(state);
-  r=alloc_small(3 * Double_wosize, Double_array_tag);
+  r=caml_alloc_small(3 * Double_wosize, Double_array_tag);
   Store_double_field(r, 0, s->result);
   Store_double_field(r, 1, s->sigma);
   Store_double_field(r, 2, s->chisq);
@@ -314,7 +314,7 @@ CAMLprim value ml_gsl_monte_vegas_get_params(value state)
   {
     value vchan;
     if(Is_some(GSLVEGASSTREAM_VAL(state))){
-      vchan=alloc_small(1, 0);
+      vchan=caml_alloc_small(1, 0);
       Field(vchan, 0)=GSLVEGASSTREAM_VAL(state);
     }
     else

--- a/src/mlgsl_monte.c
+++ b/src/mlgsl_monte.c
@@ -188,11 +188,11 @@ CAMLprim value ml_gsl_monte_miser_get_params(value state)
   CAMLlocal1(r);
   gsl_monte_miser_state *s = GSLMISERSTATE_VAL(state);
   r=alloc_tuple(5);
-  Store_field(r, 0, copy_double(s->estimate_frac));
+  Store_field(r, 0, caml_copy_double(s->estimate_frac));
   Store_field(r, 1, Val_int(s->min_calls));
   Store_field(r, 2, Val_int(s->min_calls_per_bisection));
-  Store_field(r, 3, copy_double(s->alpha));
-  Store_field(r, 4, copy_double(s->dither));
+  Store_field(r, 3, caml_copy_double(s->alpha));
+  Store_field(r, 4, caml_copy_double(s->dither));
   CAMLreturn(r);
 }
 
@@ -306,7 +306,7 @@ CAMLprim value ml_gsl_monte_vegas_get_params(value state)
   CAMLlocal1(r);
   gsl_monte_vegas_state *s = GSLVEGASSTATE_VAL(state);
   r=alloc_tuple(6);
-  Store_field(r, 0, copy_double(s->alpha));
+  Store_field(r, 0, caml_copy_double(s->alpha));
   Store_field(r, 1, Val_int(s->iterations));
   Store_field(r, 2, Val_int(s->stage));
   Store_field(r, 3, Val_int(s->mode + 1));

--- a/src/mlgsl_monte.c
+++ b/src/mlgsl_monte.c
@@ -338,7 +338,7 @@ CAMLprim value ml_gsl_monte_vegas_set_params(value state, value params)
       struct channel *chan=Channel(Field(vchan, 0));
       if(s->ostream != stdout && s->ostream != stderr) 
 	fclose(s->ostream);
-      flush(chan);
+      caml_flush(chan);
       s->ostream = fdopen(dup(chan->fd), "w");
       GSLVEGASSTREAM_VAL(state) = vchan;
     }

--- a/src/mlgsl_monte.c
+++ b/src/mlgsl_monte.c
@@ -58,8 +58,8 @@ CAMLprim value ml_gsl_monte_plain_alloc(value d)
     params->closure = Val_unit;
     params->dbl = caml_alloc(dim * Double_wosize, Double_array_tag);
   
-    register_global_root(&(params->closure));
-    register_global_root(&(params->dbl));
+    caml_register_global_root(&(params->closure));
+    caml_register_global_root(&(params->dbl));
     CAMLreturn(res);
   }
 }
@@ -68,8 +68,8 @@ ML1(gsl_monte_plain_init, GSLPLAINSTATE_VAL, Unit)
 
 CAMLprim value ml_gsl_monte_plain_free(value s)
 {
-  remove_global_root(&(CallbackParams_val(s)->closure));
-  remove_global_root(&(CallbackParams_val(s)->dbl));
+  caml_remove_global_root(&(CallbackParams_val(s)->closure));
+  caml_remove_global_root(&(CallbackParams_val(s)->dbl));
   caml_stat_free(CallbackParams_val(s));
   gsl_monte_plain_free(GSLPLAINSTATE_VAL(s));
   return Val_unit;
@@ -133,8 +133,8 @@ CAMLprim value ml_gsl_monte_miser_alloc(value d)
     params->closure = Val_unit;
     params->dbl = caml_alloc(dim * Double_wosize, Double_array_tag);
   
-    register_global_root(&(params->closure));
-    register_global_root(&(params->dbl));
+    caml_register_global_root(&(params->closure));
+    caml_register_global_root(&(params->dbl));
     CAMLreturn(res);
   }
 }
@@ -143,8 +143,8 @@ ML1(gsl_monte_miser_init, GSLMISERSTATE_VAL, Unit)
 
 CAMLprim value ml_gsl_monte_miser_free(value s)
 {
-  remove_global_root(&(CallbackParams_val(s)->closure));
-  remove_global_root(&(CallbackParams_val(s)->dbl));
+  caml_remove_global_root(&(CallbackParams_val(s)->closure));
+  caml_remove_global_root(&(CallbackParams_val(s)->dbl));
   caml_stat_free(CallbackParams_val(s));
   gsl_monte_miser_free(GSLMISERSTATE_VAL(s));
   return Val_unit;
@@ -235,9 +235,9 @@ CAMLprim value ml_gsl_monte_vegas_alloc(value d)
     params->closure = Val_unit;
     params->dbl = caml_alloc(dim * Double_wosize, Double_array_tag);
     
-    register_global_root(&(params->closure));
-    register_global_root(&(params->dbl));
-    register_global_root(&(Field(res, 2)));
+    caml_register_global_root(&(params->closure));
+    caml_register_global_root(&(params->dbl));
+    caml_register_global_root(&(Field(res, 2)));
     CAMLreturn(res);
   }
 }
@@ -247,12 +247,12 @@ ML1(gsl_monte_vegas_init, GSLVEGASSTATE_VAL, Unit)
 CAMLprim value ml_gsl_monte_vegas_free(value state)
 {
   gsl_monte_vegas_state *s=GSLVEGASSTATE_VAL(state);
-  remove_global_root(&(CallbackParams_val(state)->closure));
-  remove_global_root(&(CallbackParams_val(state)->dbl));
+  caml_remove_global_root(&(CallbackParams_val(state)->closure));
+  caml_remove_global_root(&(CallbackParams_val(state)->dbl));
   caml_stat_free(CallbackParams_val(state));
   if(s->ostream != stdout && s->ostream != stderr)
     fclose(s->ostream);
-  remove_global_root(&GSLVEGASSTREAM_VAL(state));
+  caml_remove_global_root(&GSLVEGASSTREAM_VAL(state));
   gsl_monte_vegas_free(s);
   return Val_unit;
 }

--- a/src/mlgsl_monte.c
+++ b/src/mlgsl_monte.c
@@ -43,7 +43,7 @@ CAMLprim value ml_gsl_monte_plain_alloc(value d)
   int dim=Int_val(d);
 
   s=gsl_monte_plain_alloc(dim);
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   {
     CAMLparam0();
@@ -70,7 +70,7 @@ CAMLprim value ml_gsl_monte_plain_free(value s)
 {
   remove_global_root(&(CallbackParams_val(s)->closure));
   remove_global_root(&(CallbackParams_val(s)->dbl));
-  stat_free(CallbackParams_val(s));
+  caml_stat_free(CallbackParams_val(s));
   gsl_monte_plain_free(GSLPLAINSTATE_VAL(s));
   return Val_unit;
 }
@@ -119,7 +119,7 @@ CAMLprim value ml_gsl_monte_miser_alloc(value d)
   int dim=Int_val(d);
 
   s=gsl_monte_miser_alloc(dim);
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   {
     CAMLparam0();
@@ -145,7 +145,7 @@ CAMLprim value ml_gsl_monte_miser_free(value s)
 {
   remove_global_root(&(CallbackParams_val(s)->closure));
   remove_global_root(&(CallbackParams_val(s)->dbl));
-  stat_free(CallbackParams_val(s));
+  caml_stat_free(CallbackParams_val(s));
   gsl_monte_miser_free(GSLMISERSTATE_VAL(s));
   return Val_unit;
 }
@@ -220,7 +220,7 @@ CAMLprim value ml_gsl_monte_vegas_alloc(value d)
   int dim=Int_val(d);
 
   s=gsl_monte_vegas_alloc(dim);
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   {
     CAMLparam0();
@@ -249,7 +249,7 @@ CAMLprim value ml_gsl_monte_vegas_free(value state)
   gsl_monte_vegas_state *s=GSLVEGASSTATE_VAL(state);
   remove_global_root(&(CallbackParams_val(state)->closure));
   remove_global_root(&(CallbackParams_val(state)->dbl));
-  stat_free(CallbackParams_val(state));
+  caml_stat_free(CallbackParams_val(state));
   if(s->ostream != stdout && s->ostream != stderr)
     fclose(s->ostream);
   remove_global_root(&GSLVEGASSTREAM_VAL(state));

--- a/src/mlgsl_multifit.c
+++ b/src/mlgsl_multifit.c
@@ -45,7 +45,7 @@ CAMLprim value ml_gsl_multifit_fdfsolver_alloc(value type, value n, value p)
   params->gslfun.mffdf.params = params;
   params->closure = Val_unit;
   params->dbl     = Val_unit;
-  register_global_root(&(params->closure));
+  caml_register_global_root(&(params->closure));
   return res;
 }
 #define FDFSOLVER_VAL(v) ((gsl_multifit_fdfsolver *)(Field(v, 0)))
@@ -65,7 +65,7 @@ CAMLprim value ml_gsl_multifit_fdfsolver_set(value S, value fun, value x)
 CAMLprim value ml_gsl_multifit_fdfsolver_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
-  remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->closure));
   caml_stat_free(p);
   gsl_multifit_fdfsolver_free(FDFSOLVER_VAL(S));
   return Val_unit;

--- a/src/mlgsl_multifit.c
+++ b/src/mlgsl_multifit.c
@@ -31,7 +31,7 @@ CAMLprim value ml_gsl_multifit_fdfsolver_alloc(value type, value n, value p)
 
   S=gsl_multifit_fdfsolver_alloc(fdfsolver_of_value(type), 
 				 Int_val(n), Int_val(p));
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)S;
@@ -66,7 +66,7 @@ CAMLprim value ml_gsl_multifit_fdfsolver_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
   remove_global_root(&(p->closure));
-  stat_free(p);
+  caml_stat_free(p);
   gsl_multifit_fdfsolver_free(FDFSOLVER_VAL(S));
   return Val_unit;
 }

--- a/src/mlgsl_multifit.c
+++ b/src/mlgsl_multifit.c
@@ -33,7 +33,7 @@ CAMLprim value ml_gsl_multifit_fdfsolver_alloc(value type, value n, value p)
 				 Int_val(n), Int_val(p));
   params=stat_alloc(sizeof(*params));
 
-  res=alloc_small(2, Abstract_tag);
+  res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)S;
   Field(res, 1) = (value)params;
 

--- a/src/mlgsl_multifit.c
+++ b/src/mlgsl_multifit.c
@@ -71,7 +71,7 @@ CAMLprim value ml_gsl_multifit_fdfsolver_free(value S)
   return Val_unit;
 }
 
-ML1(gsl_multifit_fdfsolver_name, FDFSOLVER_VAL, copy_string)
+ML1(gsl_multifit_fdfsolver_name, FDFSOLVER_VAL, caml_copy_string)
 
 ML1(gsl_multifit_fdfsolver_iterate, FDFSOLVER_VAL, Unit)
 

--- a/src/mlgsl_multimin.c
+++ b/src/mlgsl_multimin.c
@@ -105,7 +105,7 @@ CAMLprim value ml_gsl_multimin_fdfminimizer_minimum(value ox, value odx, value o
       gsl_vector_memcpy(&v_g,  
 			gsl_multimin_fdfminimizer_gradient(t));
   }
-  return copy_double(gsl_multimin_fdfminimizer_minimum(t));
+  return caml_copy_double(gsl_multimin_fdfminimizer_minimum(t));
 }
 
 CAMLprim value ml_gsl_multimin_test_gradient(value S, value epsabs)
@@ -184,10 +184,10 @@ CAMLprim value ml_gsl_multimin_fminimizer_minimum(value ox, value T)
       _CONVERT_VECTOR(x);
       gsl_vector_memcpy(&v_x, gsl_multimin_fminimizer_x(t));
   }
-  return copy_double(gsl_multimin_fminimizer_minimum(t));
+  return caml_copy_double(gsl_multimin_fminimizer_minimum(t));
 }
 
-ML1(gsl_multimin_fminimizer_size, GSLMULTIMINFMINIMIZER_VAL, copy_double)
+ML1(gsl_multimin_fminimizer_size, GSLMULTIMINFMINIMIZER_VAL, caml_copy_double)
 
 CAMLprim value ml_gsl_multimin_test_size(value S, value epsabs)
 {

--- a/src/mlgsl_multimin.c
+++ b/src/mlgsl_multimin.c
@@ -48,7 +48,7 @@ CAMLprim value ml_gsl_multimin_fdfminimizer_alloc(value type, value d)
   params->gslfun.mmfdf.params = params;
   params->closure = Val_unit;
   params->dbl     = Val_unit;
-  register_global_root(&(params->closure));
+  caml_register_global_root(&(params->closure));
   return res;
 }
 #define GSLMULTIMINFDFMINIMIZER_VAL(v) ((gsl_multimin_fdfminimizer *)(Field(v, 0)))
@@ -71,7 +71,7 @@ CAMLprim value ml_gsl_multimin_fdfminimizer_set(value S, value fun, value X,
 CAMLprim value ml_gsl_multimin_fdfminimizer_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
-  remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->closure));
   caml_stat_free(p);
   gsl_multimin_fdfminimizer_free(GSLMULTIMINFDFMINIMIZER_VAL(S));
   return Val_unit;
@@ -145,7 +145,7 @@ CAMLprim value ml_gsl_multimin_fminimizer_alloc(value type, value d)
   params->gslfun.mmf.params = params;
   params->closure = Val_unit;
   params->dbl     = Val_unit;
-  register_global_root(&(params->closure));
+  caml_register_global_root(&(params->closure));
   return res;
 }
 #define GSLMULTIMINFMINIMIZER_VAL(v) ((gsl_multimin_fminimizer *)(Field(v, 0)))
@@ -166,7 +166,7 @@ CAMLprim value ml_gsl_multimin_fminimizer_set(value S, value fun,
 CAMLprim value ml_gsl_multimin_fminimizer_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
-  remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->closure));
   caml_stat_free(p);
   gsl_multimin_fminimizer_free(GSLMULTIMINFMINIMIZER_VAL(S));
   return Val_unit;

--- a/src/mlgsl_multimin.c
+++ b/src/mlgsl_multimin.c
@@ -35,7 +35,7 @@ CAMLprim value ml_gsl_multimin_fdfminimizer_alloc(value type, value d)
   value res;
 
   T=gsl_multimin_fdfminimizer_alloc(fdfminimizer_of_value(type), dim);
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)T;
@@ -72,7 +72,7 @@ CAMLprim value ml_gsl_multimin_fdfminimizer_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
   remove_global_root(&(p->closure));
-  stat_free(p);
+  caml_stat_free(p);
   gsl_multimin_fdfminimizer_free(GSLMULTIMINFDFMINIMIZER_VAL(S));
   return Val_unit;
 }
@@ -134,7 +134,7 @@ CAMLprim value ml_gsl_multimin_fminimizer_alloc(value type, value d)
   value res;
 
   T=gsl_multimin_fminimizer_alloc(fminimizer_of_value(type), dim);
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)T;
@@ -167,7 +167,7 @@ CAMLprim value ml_gsl_multimin_fminimizer_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
   remove_global_root(&(p->closure));
-  stat_free(p);
+  caml_stat_free(p);
   gsl_multimin_fminimizer_free(GSLMULTIMINFMINIMIZER_VAL(S));
   return Val_unit;
 }

--- a/src/mlgsl_multimin.c
+++ b/src/mlgsl_multimin.c
@@ -37,7 +37,7 @@ CAMLprim value ml_gsl_multimin_fdfminimizer_alloc(value type, value d)
   T=gsl_multimin_fdfminimizer_alloc(fdfminimizer_of_value(type), dim);
   params=stat_alloc(sizeof(*params));
 
-  res=alloc_small(2, Abstract_tag);
+  res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)T;
   Field(res, 1) = (value)params;
 
@@ -136,7 +136,7 @@ CAMLprim value ml_gsl_multimin_fminimizer_alloc(value type, value d)
   T=gsl_multimin_fminimizer_alloc(fminimizer_of_value(type), dim);
   params=stat_alloc(sizeof(*params));
 
-  res=alloc_small(2, Abstract_tag);
+  res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)T;
   Field(res, 1) = (value)params;
 

--- a/src/mlgsl_multimin.c
+++ b/src/mlgsl_multimin.c
@@ -77,7 +77,7 @@ CAMLprim value ml_gsl_multimin_fdfminimizer_free(value S)
   return Val_unit;
 }
 
-ML1(gsl_multimin_fdfminimizer_name, GSLMULTIMINFDFMINIMIZER_VAL, copy_string)
+ML1(gsl_multimin_fdfminimizer_name, GSLMULTIMINFDFMINIMIZER_VAL, caml_copy_string)
 ML1(gsl_multimin_fdfminimizer_iterate, GSLMULTIMINFDFMINIMIZER_VAL, Unit)
 ML1(gsl_multimin_fdfminimizer_restart, GSLMULTIMINFDFMINIMIZER_VAL, Unit)
 
@@ -172,7 +172,7 @@ CAMLprim value ml_gsl_multimin_fminimizer_free(value S)
   return Val_unit;
 }
 
-ML1(gsl_multimin_fminimizer_name, GSLMULTIMINFMINIMIZER_VAL, copy_string)
+ML1(gsl_multimin_fminimizer_name, GSLMULTIMINFMINIMIZER_VAL, caml_copy_string)
 ML1(gsl_multimin_fminimizer_iterate, GSLMULTIMINFMINIMIZER_VAL, Unit)
 
 CAMLprim value ml_gsl_multimin_fminimizer_minimum(value ox, value T)

--- a/src/mlgsl_multiroots.c
+++ b/src/mlgsl_multiroots.c
@@ -45,7 +45,7 @@ CAMLprim value ml_gsl_multiroot_fsolver_alloc(value type, value d)
   value res;
 
   S=gsl_multiroot_fsolver_alloc(fsolver_of_value(type), dim);
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)S;
@@ -68,7 +68,7 @@ CAMLprim value ml_gsl_multiroot_fdfsolver_alloc(value type, value d)
   value res;
 
   S=gsl_multiroot_fdfsolver_alloc(fdfsolver_of_value(type), dim);
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)S;
@@ -116,7 +116,7 @@ CAMLprim value ml_gsl_multiroot_fsolver_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
   remove_global_root(&(p->closure));
-  stat_free(p);
+  caml_stat_free(p);
   gsl_multiroot_fsolver_free(GSLMULTIROOTSOLVER_VAL(S));
   return Val_unit;
 }
@@ -125,7 +125,7 @@ CAMLprim value ml_gsl_multiroot_fdfsolver_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
   remove_global_root(&(p->closure));
-  stat_free(p);
+  caml_stat_free(p);
   gsl_multiroot_fdfsolver_free(GSLMULTIROOTFDFSOLVER_VAL(S));
   return Val_unit;
 }

--- a/src/mlgsl_multiroots.c
+++ b/src/mlgsl_multiroots.c
@@ -47,7 +47,7 @@ CAMLprim value ml_gsl_multiroot_fsolver_alloc(value type, value d)
   S=gsl_multiroot_fsolver_alloc(fsolver_of_value(type), dim);
   params=stat_alloc(sizeof(*params));
 
-  res=alloc_small(2, Abstract_tag);
+  res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)S;
   Field(res, 1) = (value)params;
   params->gslfun.mrf.f      = &gsl_multiroot_callback;
@@ -70,7 +70,7 @@ CAMLprim value ml_gsl_multiroot_fdfsolver_alloc(value type, value d)
   S=gsl_multiroot_fdfsolver_alloc(fdfsolver_of_value(type), dim);
   params=stat_alloc(sizeof(*params));
 
-  res=alloc_small(2, Abstract_tag);
+  res=caml_alloc_small(2, Abstract_tag);
   Field(res, 0) = (value)S;
   Field(res, 1) = (value)params;
   params->gslfun.mrfdf.f      = &gsl_multiroot_callback_f;  

--- a/src/mlgsl_multiroots.c
+++ b/src/mlgsl_multiroots.c
@@ -130,8 +130,8 @@ CAMLprim value ml_gsl_multiroot_fdfsolver_free(value S)
   return Val_unit;
 }
 
-ML1(gsl_multiroot_fsolver_name, GSLMULTIROOTSOLVER_VAL, copy_string)
-ML1(gsl_multiroot_fdfsolver_name, GSLMULTIROOTFDFSOLVER_VAL, copy_string)
+ML1(gsl_multiroot_fsolver_name, GSLMULTIROOTSOLVER_VAL, caml_copy_string)
+ML1(gsl_multiroot_fdfsolver_name, GSLMULTIROOTFDFSOLVER_VAL, caml_copy_string)
 
 ML1(gsl_multiroot_fsolver_iterate, GSLMULTIROOTSOLVER_VAL, Unit)
 ML1(gsl_multiroot_fdfsolver_iterate, GSLMULTIROOTFDFSOLVER_VAL, Unit)

--- a/src/mlgsl_multiroots.c
+++ b/src/mlgsl_multiroots.c
@@ -55,7 +55,7 @@ CAMLprim value ml_gsl_multiroot_fsolver_alloc(value type, value d)
   params->gslfun.mrf.params = params;
   params->closure = Val_unit;
   params->dbl     = Val_unit; /* not needed actually */
-  register_global_root(&(params->closure));
+  caml_register_global_root(&(params->closure));
   return res;
 }
 #define GSLMULTIROOTSOLVER_VAL(v) ((gsl_multiroot_fsolver *)(Field(v, 0)))
@@ -80,7 +80,7 @@ CAMLprim value ml_gsl_multiroot_fdfsolver_alloc(value type, value d)
   params->gslfun.mrfdf.params = params;
   params->closure = Val_unit;
   params->dbl     = Val_unit; /* not needed actually */
-  register_global_root(&(params->closure));
+  caml_register_global_root(&(params->closure));
   return res;
 }
 #define GSLMULTIROOTFDFSOLVER_VAL(v) ((gsl_multiroot_fdfsolver *)(Field(v, 0)))
@@ -115,7 +115,7 @@ CAMLprim value ml_gsl_multiroot_fdfsolver_set(value S, value fun, value X)
 CAMLprim value ml_gsl_multiroot_fsolver_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
-  remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->closure));
   caml_stat_free(p);
   gsl_multiroot_fsolver_free(GSLMULTIROOTSOLVER_VAL(S));
   return Val_unit;
@@ -124,7 +124,7 @@ CAMLprim value ml_gsl_multiroot_fsolver_free(value S)
 CAMLprim value ml_gsl_multiroot_fdfsolver_free(value S)
 {
   struct callback_params *p=CALLBACKPARAMS_VAL(S);
-  remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->closure));
   caml_stat_free(p);
   gsl_multiroot_fdfsolver_free(GSLMULTIROOTFDFSOLVER_VAL(S));
   return Val_unit;

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -70,14 +70,14 @@ CAMLprim value ml_gsl_odeiv_alloc_system(value func, value ojac, value dim)
   register_global_root(&(p->closure));
   p->jac_closure = (Is_none(ojac) ? Val_unit : Unoption(ojac));
   register_global_root(&(p->jac_closure));
-  p->arr1 = alloc(Int_val(dim) * Double_wosize, Double_array_tag);
+  p->arr1 = caml_alloc(Int_val(dim) * Double_wosize, Double_array_tag);
   register_global_root(&(p->arr1));
-  p->arr2 = alloc(Int_val(dim) * Double_wosize, Double_array_tag);
+  p->arr2 = caml_alloc(Int_val(dim) * Double_wosize, Double_array_tag);
   register_global_root(&(p->arr2));
   p->mat =
     Is_none(ojac)
     ? Val_unit
-    : alloc_bigarray_dims(barr_flags, 2, NULL, Int_val(dim), Int_val(dim));
+    : caml_ba_alloc_dims(barr_flags, 2, NULL, Int_val(dim), Int_val(dim));
   register_global_root(&(p->mat));
 
   syst=stat_alloc(sizeof (*syst));

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -64,7 +64,7 @@ CAMLprim value ml_gsl_odeiv_alloc_system(value func, value ojac, value dim)
   struct mlgsl_odeiv_params *p;
   gsl_odeiv_system *syst;
   value res;
-  p=stat_alloc(sizeof (*p));
+  p=caml_stat_alloc(sizeof (*p));
   p->dim = Int_val(dim);
   p->closure = func;
   register_global_root(&(p->closure));
@@ -80,7 +80,7 @@ CAMLprim value ml_gsl_odeiv_alloc_system(value func, value ojac, value dim)
     : caml_ba_alloc_dims(barr_flags, 2, NULL, Int_val(dim), Int_val(dim));
   register_global_root(&(p->mat));
 
-  syst=stat_alloc(sizeof (*syst));
+  syst=caml_stat_alloc(sizeof (*syst));
   syst->function = ml_gsl_odeiv_func;
   syst->jacobian = ml_gsl_odeiv_jacobian;
   syst->dimension = Int_val(dim);
@@ -100,8 +100,8 @@ CAMLprim value ml_gsl_odeiv_free_system(value vsyst)
   remove_global_root(&(p->arr1));
   remove_global_root(&(p->arr2));
   remove_global_root(&(p->mat));
-  stat_free(p);
-  stat_free(syst);
+  caml_stat_free(p);
+  caml_stat_free(syst);
   return Val_unit;
 }
 

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -126,7 +126,7 @@ CAMLprim value ml_gsl_odeiv_step_alloc(value step_type, value dim)
 
 ML1(gsl_odeiv_step_free, ODEIV_STEP_VAL, Unit)
 ML1(gsl_odeiv_step_reset, ODEIV_STEP_VAL, Unit)
-ML1(gsl_odeiv_step_name, ODEIV_STEP_VAL, copy_string)
+ML1(gsl_odeiv_step_name, ODEIV_STEP_VAL, caml_copy_string)
 ML1(gsl_odeiv_step_order, ODEIV_STEP_VAL, Val_int)
 
 CAMLprim value ml_gsl_odeiv_step_apply(value step, value t, value h, value y,
@@ -218,7 +218,7 @@ CAMLprim value ml_gsl_odeiv_control_scaled_new(value eps_abs, value eps_rel,
 #define ODEIV_CONTROL_VAL(v) ((gsl_odeiv_control *)Field((v), 0))
 
 ML1(gsl_odeiv_control_free, ODEIV_CONTROL_VAL, Unit)
-ML1(gsl_odeiv_control_name, ODEIV_CONTROL_VAL, copy_string)
+ML1(gsl_odeiv_control_name, ODEIV_CONTROL_VAL, caml_copy_string)
 
 CAMLprim value ml_gsl_odeiv_control_hadjust(value c, value s, value y,
 					    value yerr, value dydt, value h)

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -67,18 +67,18 @@ CAMLprim value ml_gsl_odeiv_alloc_system(value func, value ojac, value dim)
   p=caml_stat_alloc(sizeof (*p));
   p->dim = Int_val(dim);
   p->closure = func;
-  register_global_root(&(p->closure));
+  caml_register_global_root(&(p->closure));
   p->jac_closure = (Is_none(ojac) ? Val_unit : Unoption(ojac));
-  register_global_root(&(p->jac_closure));
+  caml_register_global_root(&(p->jac_closure));
   p->arr1 = caml_alloc(Int_val(dim) * Double_wosize, Double_array_tag);
-  register_global_root(&(p->arr1));
+  caml_register_global_root(&(p->arr1));
   p->arr2 = caml_alloc(Int_val(dim) * Double_wosize, Double_array_tag);
-  register_global_root(&(p->arr2));
+  caml_register_global_root(&(p->arr2));
   p->mat =
     Is_none(ojac)
     ? Val_unit
     : caml_ba_alloc_dims(barr_flags, 2, NULL, Int_val(dim), Int_val(dim));
-  register_global_root(&(p->mat));
+  caml_register_global_root(&(p->mat));
 
   syst=caml_stat_alloc(sizeof (*syst));
   syst->function = ml_gsl_odeiv_func;
@@ -95,11 +95,11 @@ CAMLprim value ml_gsl_odeiv_free_system(value vsyst)
 {
   gsl_odeiv_system *syst = ODEIV_SYSTEM_VAL(vsyst);
   struct mlgsl_odeiv_params *p = syst->params;
-  remove_global_root(&(p->closure));
-  remove_global_root(&(p->jac_closure));
-  remove_global_root(&(p->arr1));
-  remove_global_root(&(p->arr2));
-  remove_global_root(&(p->mat));
+  caml_remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->jac_closure));
+  caml_remove_global_root(&(p->arr1));
+  caml_remove_global_root(&(p->arr2));
+  caml_remove_global_root(&(p->mat));
   caml_stat_free(p);
   caml_stat_free(syst);
   return Val_unit;

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -48,7 +48,7 @@ static int ml_gsl_odeiv_jacobian(double t, const double y[],
   args[0] = caml_copy_double(t);
   memcpy(Double_array_val(p->arr1), y, p->dim * sizeof(double));
   args[1] = p->arr1;
-  Data_bigarray_val(p->mat) = dfdy;
+  Caml_ba_data_val(p->mat) = dfdy;
   args[2] = p->mat;
   args[3] = p->arr2;
   res = callbackN_exn(p->jac_closure, 4, args);

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -30,7 +30,7 @@ static int ml_gsl_odeiv_func(double t, const double y[],
 {
   struct mlgsl_odeiv_params *p = params;
   value vt, res;
-  vt  = copy_double(t);
+  vt  = caml_copy_double(t);
   memcpy(Double_array_val(p->arr1), y, p->dim * sizeof(double));
   res = callback3_exn(p->closure, vt, p->arr1, p->arr2);
   if(Is_exception_result(res))
@@ -45,7 +45,7 @@ static int ml_gsl_odeiv_jacobian(double t, const double y[],
 {
   struct mlgsl_odeiv_params *p = params;
   value res, args[4];
-  args[0] = copy_double(t);
+  args[0] = caml_copy_double(t);
   memcpy(Double_array_val(p->arr1), y, p->dim * sizeof(double));
   args[1] = p->arr1;
   Data_bigarray_val(p->mat) = dfdy;
@@ -231,7 +231,7 @@ CAMLprim value ml_gsl_odeiv_control_hadjust(value c, value s, value y,
   {
     CAMLparam0();
     CAMLlocal2(vh, r);
-    vh = copy_double(c_h);
+    vh = caml_copy_double(c_h);
     r = alloc_small(2, 0);
     Field(r, 0) = Val_int(status + 1);
     Field(r, 1) = vh;

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -51,7 +51,7 @@ static int ml_gsl_odeiv_jacobian(double t, const double y[],
   Caml_ba_data_val(p->mat) = dfdy;
   args[2] = p->mat;
   args[3] = p->arr2;
-  res = callbackN_exn(p->jac_closure, 4, args);
+  res = caml_callbackN_exn(p->jac_closure, 4, args);
   if(Is_exception_result(res))
     return GSL_FAILURE;
   memcpy(dfdt, Double_array_val(p->arr2), p->dim * sizeof(double));

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -32,7 +32,7 @@ static int ml_gsl_odeiv_func(double t, const double y[],
   value vt, res;
   vt  = caml_copy_double(t);
   memcpy(Double_array_val(p->arr1), y, p->dim * sizeof(double));
-  res = callback3_exn(p->closure, vt, p->arr1, p->arr2);
+  res = caml_callback3_exn(p->closure, vt, p->arr1, p->arr2);
   if(Is_exception_result(res))
     return GSL_FAILURE;
   memcpy(dydt, Double_array_val(p->arr2), p->dim * sizeof(double));

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -232,7 +232,7 @@ CAMLprim value ml_gsl_odeiv_control_hadjust(value c, value s, value y,
     CAMLparam0();
     CAMLlocal2(vh, r);
     vh = caml_copy_double(c_h);
-    r = alloc_small(2, 0);
+    r = caml_alloc_small(2, 0);
     Field(r, 0) = Val_int(status + 1);
     Field(r, 1) = vh;
     CAMLreturn(r);

--- a/src/mlgsl_odeiv.c
+++ b/src/mlgsl_odeiv.c
@@ -60,7 +60,7 @@ static int ml_gsl_odeiv_jacobian(double t, const double y[],
 
 CAMLprim value ml_gsl_odeiv_alloc_system(value func, value ojac, value dim)
 {
-  const int barr_flags = BIGARRAY_FLOAT64 | BIGARRAY_C_LAYOUT | BIGARRAY_EXTERNAL;
+  const int barr_flags = CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL;
   struct mlgsl_odeiv_params *p;
   gsl_odeiv_system *syst;
   value res;

--- a/src/mlgsl_permut.c
+++ b/src/mlgsl_permut.c
@@ -67,7 +67,7 @@ CAMLprim value ml_gsl_permute(value p, value arr)
 CAMLprim value ml_gsl_permute_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
-  struct caml_bigarray *barr = Bigarray_val(arr);
+  struct caml_bigarray *barr = Caml_ba_array_val(arr);
   enum caml_bigarray_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
   switch(kind){
   case BIGARRAY_FLOAT32:
@@ -122,7 +122,7 @@ CAMLprim value ml_gsl_permute_inverse(value p, value arr)
 CAMLprim value ml_gsl_permute_inverse_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
-  struct caml_bigarray *barr = Bigarray_val(arr);
+  struct caml_bigarray *barr = Caml_ba_array_val(arr);
   enum caml_bigarray_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
   switch(kind){
   case BIGARRAY_FLOAT32:

--- a/src/mlgsl_permut.c
+++ b/src/mlgsl_permut.c
@@ -68,31 +68,31 @@ CAMLprim value ml_gsl_permute_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
   struct caml_ba_array *barr = Caml_ba_array_val(arr);
-  enum caml_ba_array_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
+  enum caml_ba_array_kind kind = (barr->flags) & CAML_BA_KIND_MASK ;
   switch(kind){
-  case BIGARRAY_FLOAT32:
+  case CAML_BA_FLOAT32:
     gsl_permute_float(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_FLOAT64:
+  case CAML_BA_FLOAT64:
     gsl_permute(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_SINT8:
+  case CAML_BA_SINT8:
     gsl_permute_char(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_UINT8:
+  case CAML_BA_UINT8:
     gsl_permute_uchar(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_SINT16:
+  case CAML_BA_SINT16:
     gsl_permute_short(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_UINT16:
+  case CAML_BA_UINT16:
     gsl_permute_ushort(perm_p.data, barr->data, 1, barr->dim[0]); break;
 #ifdef ARCH_SIXTYFOUR
-  case BIGARRAY_INT64:
+  case CAML_BA_INT64:
 #else
-  case BIGARRAY_INT32:
+  case CAML_BA_INT32:
 #endif
-  case BIGARRAY_CAML_INT:
-  case BIGARRAY_NATIVE_INT:
+  case CAML_BA_CAML_INT:
+  case CAML_BA_NATIVE_INT:
     gsl_permute_long(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_COMPLEX32:
+  case CAML_BA_COMPLEX32:
     gsl_permute_complex_float(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_COMPLEX64:
+  case CAML_BA_COMPLEX64:
     gsl_permute_complex(perm_p.data, barr->data, 1, barr->dim[0]); break;
   default: 
     GSL_ERROR("data type not supported", GSL_EUNIMPL);
@@ -123,31 +123,31 @@ CAMLprim value ml_gsl_permute_inverse_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
   struct caml_ba_array *barr = Caml_ba_array_val(arr);
-  enum caml_ba_array_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
+  enum caml_ba_array_kind kind = (barr->flags) & CAML_BA_KIND_MASK ;
   switch(kind){
-  case BIGARRAY_FLOAT32:
+  case CAML_BA_FLOAT32:
     gsl_permute_float_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_FLOAT64:
+  case CAML_BA_FLOAT64:
     gsl_permute_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_SINT8:
+  case CAML_BA_SINT8:
     gsl_permute_char_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_UINT8:
+  case CAML_BA_UINT8:
     gsl_permute_uchar_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_SINT16:
+  case CAML_BA_SINT16:
     gsl_permute_short_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_UINT16:
+  case CAML_BA_UINT16:
     gsl_permute_ushort_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
 #ifdef ARCH_SIXTYFOUR
-  case BIGARRAY_INT64:
+  case CAML_BA_INT64:
 #else
-  case BIGARRAY_INT32:
+  case CAML_BA_INT32:
 #endif
-  case BIGARRAY_CAML_INT:
-  case BIGARRAY_NATIVE_INT:
+  case CAML_BA_CAML_INT:
+  case CAML_BA_NATIVE_INT:
     gsl_permute_long_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_COMPLEX32:
+  case CAML_BA_COMPLEX32:
     gsl_permute_complex_float_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
-  case BIGARRAY_COMPLEX64:
+  case CAML_BA_COMPLEX64:
     gsl_permute_complex_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;
   default:
     GSL_ERROR("data type not supported", GSL_EUNIMPL);

--- a/src/mlgsl_permut.c
+++ b/src/mlgsl_permut.c
@@ -68,7 +68,7 @@ CAMLprim value ml_gsl_permute_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
   struct caml_ba_array *barr = Caml_ba_array_val(arr);
-  enum caml_ba_array_kind kind = (barr->flags) & CAML_BA_KIND_MASK ;
+  enum caml_ba_kind kind = (barr->flags) & CAML_BA_KIND_MASK ;
   switch(kind){
   case CAML_BA_FLOAT32:
     gsl_permute_float(perm_p.data, barr->data, 1, barr->dim[0]); break;
@@ -123,7 +123,7 @@ CAMLprim value ml_gsl_permute_inverse_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
   struct caml_ba_array *barr = Caml_ba_array_val(arr);
-  enum caml_ba_array_kind kind = (barr->flags) & CAML_BA_KIND_MASK ;
+  enum caml_ba_kind kind = (barr->flags) & CAML_BA_KIND_MASK ;
   switch(kind){
   case CAML_BA_FLOAT32:
     gsl_permute_float_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;

--- a/src/mlgsl_permut.c
+++ b/src/mlgsl_permut.c
@@ -67,8 +67,8 @@ CAMLprim value ml_gsl_permute(value p, value arr)
 CAMLprim value ml_gsl_permute_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
-  struct caml_bigarray *barr = Caml_ba_array_val(arr);
-  enum caml_bigarray_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
+  struct caml_ba_array *barr = Caml_ba_array_val(arr);
+  enum caml_ba_array_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
   switch(kind){
   case BIGARRAY_FLOAT32:
     gsl_permute_float(perm_p.data, barr->data, 1, barr->dim[0]); break;
@@ -122,8 +122,8 @@ CAMLprim value ml_gsl_permute_inverse(value p, value arr)
 CAMLprim value ml_gsl_permute_inverse_barr(value p, value arr)
 {
   GSL_PERMUT_OF_BIGARRAY(p);
-  struct caml_bigarray *barr = Caml_ba_array_val(arr);
-  enum caml_bigarray_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
+  struct caml_ba_array *barr = Caml_ba_array_val(arr);
+  enum caml_ba_array_kind kind = (barr->flags) & BIGARRAY_KIND_MASK ;
   switch(kind){
   case BIGARRAY_FLOAT32:
     gsl_permute_float_inverse(perm_p.data, barr->data, 1, barr->dim[0]); break;

--- a/src/mlgsl_permut.h
+++ b/src/mlgsl_permut.h
@@ -6,7 +6,7 @@
 #include <caml/bigarray.h>
 
 #define GSL_PERMUT_OF_BIGARRAY(arr) \
-  struct caml_bigarray *bigarr_##arr = Caml_ba_array_val(arr); \
+  struct caml_ba_array *bigarr_##arr = Caml_ba_array_val(arr); \
   gsl_permutation perm_##arr = { \
       /*.size =*/ bigarr_##arr->dim[0], \
       /*.data =*/ bigarr_##arr->data }

--- a/src/mlgsl_permut.h
+++ b/src/mlgsl_permut.h
@@ -6,7 +6,7 @@
 #include <caml/bigarray.h>
 
 #define GSL_PERMUT_OF_BIGARRAY(arr) \
-  struct caml_bigarray *bigarr_##arr = Bigarray_val(arr); \
+  struct caml_bigarray *bigarr_##arr = Caml_ba_array_val(arr); \
   gsl_permutation perm_##arr = { \
       /*.size =*/ bigarr_##arr->dim[0], \
       /*.data =*/ bigarr_##arr->data }

--- a/src/mlgsl_poly.c
+++ b/src/mlgsl_poly.c
@@ -29,7 +29,7 @@ CAMLprim value ml_gsl_poly_solve_quadratic(value a, value b, value c)
     if(n == 0)
       r = Val_int(0);
     else{
-      r = alloc(2, 0);
+      r = caml_alloc(2, 0);
       Store_field(r, 0, caml_copy_double(x0));
       Store_field(r, 1, caml_copy_double(x1));
     } ;
@@ -74,11 +74,11 @@ CAMLprim value ml_gsl_poly_solve_cubic(value a, value b, value c)
     case 0:
       break;
     case 1:
-      r = alloc(1, 0);
+      r = caml_alloc(1, 0);
       Store_field(r, 0, caml_copy_double(x0));
       break;
     case 3:
-      r = alloc(3, 1);
+      r = caml_alloc(3, 1);
       Store_field(r, 0, caml_copy_double(x0));
       Store_field(r, 1, caml_copy_double(x1));
       Store_field(r, 2, caml_copy_double(x2));

--- a/src/mlgsl_poly.c
+++ b/src/mlgsl_poly.c
@@ -14,7 +14,7 @@
 CAMLprim value ml_gsl_poly_eval(value c, value x)
 {
   int len = Double_array_length(c);
-  return copy_double(gsl_poly_eval(Double_array_val(c), len, Double_val(x)));
+  return caml_copy_double(gsl_poly_eval(Double_array_val(c), len, Double_val(x)));
 }
 
 CAMLprim value ml_gsl_poly_solve_quadratic(value a, value b, value c)
@@ -30,8 +30,8 @@ CAMLprim value ml_gsl_poly_solve_quadratic(value a, value b, value c)
       r = Val_int(0);
     else{
       r = alloc(2, 0);
-      Store_field(r, 0, copy_double(x0));
-      Store_field(r, 1, copy_double(x1));
+      Store_field(r, 0, caml_copy_double(x0));
+      Store_field(r, 1, caml_copy_double(x1));
     } ;
     CAMLreturn(r);
   }
@@ -75,13 +75,13 @@ CAMLprim value ml_gsl_poly_solve_cubic(value a, value b, value c)
       break;
     case 1:
       r = alloc(1, 0);
-      Store_field(r, 0, copy_double(x0));
+      Store_field(r, 0, caml_copy_double(x0));
       break;
     case 3:
       r = alloc(3, 1);
-      Store_field(r, 0, copy_double(x0));
-      Store_field(r, 1, copy_double(x1));
-      Store_field(r, 2, copy_double(x2));
+      Store_field(r, 0, caml_copy_double(x0));
+      Store_field(r, 1, caml_copy_double(x1));
+      Store_field(r, 2, caml_copy_double(x2));
     } ;
     CAMLreturn(r);
   };

--- a/src/mlgsl_poly.c
+++ b/src/mlgsl_poly.c
@@ -46,13 +46,13 @@ CAMLprim value ml_gsl_poly_complex_solve_quadratic(value a, value b, value c)
   { 
     CAMLparam0();
     CAMLlocal3(r,rz0,rz1);
-    rz0 = alloc_small(2 * Double_wosize, Double_array_tag);
+    rz0 = caml_alloc_small(2 * Double_wosize, Double_array_tag);
     Store_double_field(rz0, 0, GSL_REAL(z0));
     Store_double_field(rz0, 1, GSL_IMAG(z0));
-    rz1 = alloc_small(2 * Double_wosize, Double_array_tag);
+    rz1 = caml_alloc_small(2 * Double_wosize, Double_array_tag);
     Store_double_field(rz1, 0, GSL_REAL(z1));
     Store_double_field(rz1, 1, GSL_IMAG(z1));
-    r   = alloc_small(2, 0);
+    r   = caml_alloc_small(2, 0);
     Field(r,0) = rz0 ;
     Field(r,1) = rz1 ; 
     CAMLreturn(r);
@@ -95,16 +95,16 @@ CAMLprim value ml_gsl_poly_complex_solve_cubic(value a, value b, value c)
   {
     CAMLparam0();
     CAMLlocal4(r,rz0, rz1, rz2);
-    rz0 = alloc_small(2 * Double_wosize, Double_array_tag);
+    rz0 = caml_alloc_small(2 * Double_wosize, Double_array_tag);
     Store_double_field(rz0, 0, GSL_REAL(z0));
     Store_double_field(rz0, 1, GSL_IMAG(z0));
-    rz1 = alloc_small(2 * Double_wosize, Double_array_tag);
+    rz1 = caml_alloc_small(2 * Double_wosize, Double_array_tag);
     Store_double_field(rz1, 0, GSL_REAL(z1));
     Store_double_field(rz1, 1, GSL_IMAG(z1));
-    rz2 = alloc_small(2 * Double_wosize, Double_array_tag);
+    rz2 = caml_alloc_small(2 * Double_wosize, Double_array_tag);
     Store_double_field(rz2, 0, GSL_REAL(z2));
     Store_double_field(rz2, 1, GSL_IMAG(z2));
-    r   = alloc_small(3, 0);
+    r   = caml_alloc_small(3, 0);
     Field(r,0) = rz0 ;
     Field(r,1) = rz1 ;
     Field(r,2) = rz2 ;

--- a/src/mlgsl_qrng.c
+++ b/src/mlgsl_qrng.c
@@ -48,7 +48,7 @@ CAMLprim value ml_gsl_qrng_sample(value qrng)
   return arr;
 }
 
-ML1(gsl_qrng_name, Qrng_val, copy_string)
+ML1(gsl_qrng_name, Qrng_val, caml_copy_string)
 
 CAMLprim value ml_gsl_qrng_memcpy(value src, value dst)
 {

--- a/src/mlgsl_qrng.c
+++ b/src/mlgsl_qrng.c
@@ -43,7 +43,7 @@ CAMLprim value ml_gsl_qrng_get(value qrng, value x)
 CAMLprim value ml_gsl_qrng_sample(value qrng)
 {
   gsl_qrng * q = Qrng_val(qrng);
-  value arr = alloc(q->dimension * Double_wosize, Double_array_tag);
+  value arr = caml_alloc(q->dimension * Double_wosize, Double_array_tag);
   gsl_qrng_get(q, Double_array_val(arr));
   return arr;
 }

--- a/src/mlgsl_randist.c
+++ b/src/mlgsl_randist.c
@@ -14,22 +14,22 @@
 #include "mlgsl_matrix_double.h"
 
 /* GAUSSIAN */
-ML2(gsl_ran_gaussian, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_gaussian_ratio_method, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_gaussian_ziggurat, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_gaussian_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_gaussian, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_gaussian_ratio_method, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_gaussian_ziggurat, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_gaussian_pdf, Double_val, Double_val, caml_copy_double)
 
-ML1(gsl_ran_ugaussian, Rng_val, copy_double)
-ML1(gsl_ran_ugaussian_ratio_method, Rng_val, copy_double)
-ML1(gsl_ran_ugaussian_pdf, Double_val, copy_double)
+ML1(gsl_ran_ugaussian, Rng_val, caml_copy_double)
+ML1(gsl_ran_ugaussian_ratio_method, Rng_val, caml_copy_double)
+ML1(gsl_ran_ugaussian_pdf, Double_val, caml_copy_double)
 
 
 /* GAUSSIAN TAIL */
-ML3(gsl_ran_gaussian_tail, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_gaussian_tail_pdf, Double_val, Double_val, Double_val ,copy_double)
+ML3(gsl_ran_gaussian_tail, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_gaussian_tail_pdf, Double_val, Double_val, Double_val ,caml_copy_double)
 
-ML2(gsl_ran_ugaussian_tail, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_ugaussian_tail_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_ugaussian_tail, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_ugaussian_tail_pdf, Double_val, Double_val, caml_copy_double)
 
 
 /* BIVARIATE */
@@ -42,7 +42,7 @@ CAMLprim value ml_gsl_ran_bivariate_gaussian(value rng, value sigma_x, value sig
 			     Double_val(rho), &x, &y);
   return copy_two_double(x, y);
 }
-ML5(gsl_ran_bivariate_gaussian_pdf, Double_val, Double_val, Double_val, Double_val, Double_val, copy_double)
+ML5(gsl_ran_bivariate_gaussian_pdf, Double_val, Double_val, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* MULTIVARIATE */
 CAMLprim value ml_gsl_ran_multivariate_gaussian(value rng, value mu, value l, value out)
@@ -65,57 +65,57 @@ CAMLprim value ml_gsl_ran_multivariate_gaussian(value rng, value mu, value l, va
 }
 
 /* EXPONENTIAL */
-ML2(gsl_ran_exponential, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_exponential_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_exponential, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_exponential_pdf, Double_val, Double_val, caml_copy_double)
 
 /* LAPLACE */
-ML2(gsl_ran_laplace, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_laplace_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_laplace, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_laplace_pdf, Double_val, Double_val, caml_copy_double)
 
 /* EXPONENTIAL POWER */
-ML3(gsl_ran_exppow, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_exppow_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_exppow, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_exppow_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* CAUCHY */
-ML2(gsl_ran_cauchy, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_cauchy_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_cauchy, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_cauchy_pdf, Double_val, Double_val, caml_copy_double)
 
 /* RAYLEIGH */
-ML2(gsl_ran_rayleigh, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_rayleigh_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_rayleigh, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_rayleigh_pdf, Double_val, Double_val, caml_copy_double)
 
 /* RAYLEIGH TAIL */
-ML3(gsl_ran_rayleigh_tail, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_rayleigh_tail_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_rayleigh_tail, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_rayleigh_tail_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* LANDAU */
-ML1(gsl_ran_landau, Rng_val, copy_double)
-ML1(gsl_ran_landau_pdf, Double_val, copy_double)
+ML1(gsl_ran_landau, Rng_val, caml_copy_double)
+ML1(gsl_ran_landau_pdf, Double_val, caml_copy_double)
 
 /* LEVY ALPHA-STABLE */
-ML3(gsl_ran_levy, Rng_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_levy, Rng_val, Double_val, Double_val, caml_copy_double)
 
 /* LEVY SKEW ALPHA-STABLE */
-ML4(gsl_ran_levy_skew, Rng_val, Double_val, Double_val, Double_val, copy_double)
+ML4(gsl_ran_levy_skew, Rng_val, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* GAMMA */
-ML3(gsl_ran_gamma, Rng_val, Double_val, Double_val, copy_double)
-ML2(gsl_ran_gamma_int, Rng_val, Unsigned_int_val, copy_double)
-ML3(gsl_ran_gamma_pdf, Double_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_gamma_mt, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_gamma_knuth, Rng_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_gamma, Rng_val, Double_val, Double_val, caml_copy_double)
+ML2(gsl_ran_gamma_int, Rng_val, Unsigned_int_val, caml_copy_double)
+ML3(gsl_ran_gamma_pdf, Double_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_gamma_mt, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_gamma_knuth, Rng_val, Double_val, Double_val, caml_copy_double)
 
 /* FLAT */
-ML3(gsl_ran_flat, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_flat_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_flat, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_flat_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* LOGNORMAL */
-ML3(gsl_ran_lognormal, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_lognormal_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_lognormal, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_lognormal_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* CHISQ */
-ML2(gsl_ran_chisq, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_chisq_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_chisq, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_chisq_pdf, Double_val, Double_val, caml_copy_double)
 
 /* DIRICHLET */
 CAMLprim value ml_gsl_ran_dirichlet(value rng, value alpha, value theta)
@@ -136,7 +136,7 @@ CAMLprim value ml_gsl_ran_dirichlet_pdf(value alpha, value theta)
     GSL_ERROR("alpha and theta must have same size", GSL_EBADLEN);
   r = gsl_ran_dirichlet_pdf(K, Double_array_val(alpha), 
 			    Double_array_val(theta));
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 CAMLprim value ml_gsl_ran_dirichlet_lnpdf(value alpha, value theta)
@@ -147,28 +147,28 @@ CAMLprim value ml_gsl_ran_dirichlet_lnpdf(value alpha, value theta)
     GSL_ERROR("alpha and theta must have same size", GSL_EBADLEN);
   r = gsl_ran_dirichlet_lnpdf(K, Double_array_val(alpha), 
 			      Double_array_val(theta));
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 /* FDIST */
-ML3(gsl_ran_fdist, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_fdist_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_fdist, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_fdist_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* TDIST */
-ML2(gsl_ran_tdist, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_tdist_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_tdist, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_tdist_pdf, Double_val, Double_val, caml_copy_double)
 
 /* BETA */
-ML3(gsl_ran_beta, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_beta_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_beta, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_beta_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* LOGISTIC */
-ML2(gsl_ran_logistic, Rng_val, Double_val, copy_double)
-ML2(gsl_ran_logistic_pdf, Double_val, Double_val, copy_double)
+ML2(gsl_ran_logistic, Rng_val, Double_val, caml_copy_double)
+ML2(gsl_ran_logistic_pdf, Double_val, Double_val, caml_copy_double)
 
 /* PARETO */
-ML3(gsl_ran_pareto, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_pareto_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_pareto, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_pareto_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* SPHERICAL */
 CAMLprim value ml_gsl_ran_dir_2d(value rng)
@@ -193,9 +193,9 @@ CAMLprim value ml_gsl_ran_dir_3d(value rng)
     CAMLparam0();
     CAMLlocal1(r);
     r=alloc_tuple(3);
-    Store_field(r, 0, copy_double(x));
-    Store_field(r, 1, copy_double(y));
-    Store_field(r, 2, copy_double(z));
+    Store_field(r, 0, caml_copy_double(x));
+    Store_field(r, 1, caml_copy_double(y));
+    Store_field(r, 2, caml_copy_double(z));
     CAMLreturn(r);
   }
 }
@@ -207,30 +207,30 @@ CAMLprim value ml_gsl_ran_dir_nd(value rng, value x)
 }
 
 /* WEIBULL */
-ML3(gsl_ran_weibull, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_weibull_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_weibull, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_weibull_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* GUMBEL1 */
-ML3(gsl_ran_gumbel1, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_gumbel1_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_gumbel1, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_gumbel1_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* GUMBEL2 */
-ML3(gsl_ran_gumbel2, Rng_val, Double_val, Double_val, copy_double)
-ML3(gsl_ran_gumbel2_pdf, Double_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_gumbel2, Rng_val, Double_val, Double_val, caml_copy_double)
+ML3(gsl_ran_gumbel2_pdf, Double_val, Double_val, Double_val, caml_copy_double)
 
 /* POISSON */
 ML2(gsl_ran_poisson, Rng_val, Double_val, Val_int)
-ML2(gsl_ran_poisson_pdf, Int_val, Double_val, copy_double)
+ML2(gsl_ran_poisson_pdf, Int_val, Double_val, caml_copy_double)
 
 /* BERNOULLI */
 ML2(gsl_ran_bernoulli, Rng_val, Double_val, Val_int)
-ML2(gsl_ran_bernoulli_pdf, Int_val, Double_val, copy_double)
+ML2(gsl_ran_bernoulli_pdf, Int_val, Double_val, caml_copy_double)
 
 /* BINOMIAL */
 ML3(gsl_ran_binomial, Rng_val, Double_val, Int_val, Val_int)
 ML3(gsl_ran_binomial_knuth, Rng_val, Double_val, Int_val, Val_int)
 ML3(gsl_ran_binomial_tpe, Rng_val, Double_val, Int_val, Val_int)
-ML3(gsl_ran_binomial_pdf, Int_val, Double_val, Int_val, copy_double)
+ML3(gsl_ran_binomial_pdf, Int_val, Double_val, Int_val, caml_copy_double)
 
 /* MULTINOMIAL */
 CAMLprim value ml_gsl_ran_multinomial(value rng, value n, value p)
@@ -257,7 +257,7 @@ CAMLprim value ml_gsl_ran_multinomial_pdf(value p, value n)
   for(i=0; i<K; i++)
     N[i] = Int_val(Field(n, i));
   r = gsl_ran_multinomial_pdf(K, Double_array_val(p), N);
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 CAMLprim value ml_gsl_ran_multinomial_lnpdf(value p, value n)
@@ -269,29 +269,29 @@ CAMLprim value ml_gsl_ran_multinomial_lnpdf(value p, value n)
   for(i=0; i<K; i++)
     N[i] = Int_val(Field(n, i));
   r = gsl_ran_multinomial_lnpdf(K, Double_array_val(p), N);
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 
 /* NEGATIVE BINOMIAL */
 ML3(gsl_ran_negative_binomial, Rng_val, Double_val, Double_val, Val_int)
-ML3(gsl_ran_negative_binomial_pdf, Int_val, Double_val, Double_val, copy_double)
+ML3(gsl_ran_negative_binomial_pdf, Int_val, Double_val, Double_val, caml_copy_double)
 
 /* PASCAL */
 ML3(gsl_ran_pascal, Rng_val, Double_val, Int_val, Val_int)
-ML3(gsl_ran_pascal_pdf, Int_val, Double_val, Int_val, copy_double)
+ML3(gsl_ran_pascal_pdf, Int_val, Double_val, Int_val, caml_copy_double)
 
 /* GEOMETRIC */
 ML2(gsl_ran_geometric, Rng_val, Double_val, Val_int)
-ML2(gsl_ran_geometric_pdf, Int_val, Double_val, copy_double)
+ML2(gsl_ran_geometric_pdf, Int_val, Double_val, caml_copy_double)
 
 /* HYPERGEOMETRIC */
 ML4(gsl_ran_hypergeometric, Rng_val, Int_val, Int_val, Int_val, Val_int)
-ML4(gsl_ran_hypergeometric_pdf, Int_val, Int_val, Int_val, Int_val, copy_double)
+ML4(gsl_ran_hypergeometric_pdf, Int_val, Int_val, Int_val, Int_val, caml_copy_double)
 
 /* LOGARITHMIC */
 ML2(gsl_ran_logarithmic, Rng_val, Double_val, Val_int)
-ML2(gsl_ran_logarithmic_pdf, Int_val, Double_val, copy_double)
+ML2(gsl_ran_logarithmic_pdf, Int_val, Double_val, caml_copy_double)
 
 
 /* SHUFFLING */
@@ -349,5 +349,5 @@ CAMLprim value ml_gsl_ran_discrete_preproc(value p)
 
 #define Discrete_val(v) ((gsl_ran_discrete_t *)(Field(v, 0)))
 ML2(gsl_ran_discrete, Rng_val, Discrete_val, Val_int)
-ML2(gsl_ran_discrete_pdf, Int_val, Discrete_val, copy_double)
+ML2(gsl_ran_discrete_pdf, Int_val, Discrete_val, caml_copy_double)
 ML1(gsl_ran_discrete_free, Discrete_val, Unit)

--- a/src/mlgsl_randist.c
+++ b/src/mlgsl_randist.c
@@ -192,7 +192,7 @@ CAMLprim value ml_gsl_ran_dir_3d(value rng)
   {
     CAMLparam0();
     CAMLlocal1(r);
-    r=alloc_tuple(3);
+    r=caml_alloc_tuple(3);
     Store_field(r, 0, caml_copy_double(x));
     Store_field(r, 1, caml_copy_double(y));
     Store_field(r, 2, caml_copy_double(z));
@@ -241,7 +241,7 @@ CAMLprim value ml_gsl_ran_multinomial(value rng, value n, value p)
   gsl_ran_multinomial(Rng_val(rng), K, Int_val(n), Double_array_val(p), N);
   {
     mlsize_t i;
-    r = alloc(K, 0);
+    r = caml_alloc(K, 0);
     for(i=0; i<K; i++)
       Store_field(r, i, Val_int(N[i]));
   }

--- a/src/mlgsl_rng.c
+++ b/src/mlgsl_rng.c
@@ -99,7 +99,7 @@ static int int_of_rngtype(const gsl_rng_type *rngt)
   if(i < len)
     return i;
   else
-    failwith("should not happen") ;
+    caml_failwith("should not happen") ;
 }
 
 value ml_gsl_rng_get_default(value unit)

--- a/src/mlgsl_rng.c
+++ b/src/mlgsl_rng.c
@@ -109,7 +109,7 @@ value ml_gsl_rng_get_default(value unit)
 
 value ml_gsl_rng_get_default_seed(value unit)
 {
-  return copy_nativeint(gsl_rng_default_seed);
+  return caml_copy_nativeint(gsl_rng_default_seed);
 }
 
 value ml_gsl_rng_set_default(value type)
@@ -150,12 +150,12 @@ value ml_gsl_rng_name(value rng)
 
 value ml_gsl_rng_max(value rng)
 {
-  return copy_nativeint(gsl_rng_max(Rng_val(rng)));
+  return caml_copy_nativeint(gsl_rng_max(Rng_val(rng)));
 }
 
 value ml_gsl_rng_min(value rng)
 {
-  return copy_nativeint(gsl_rng_min(Rng_val(rng)));
+  return caml_copy_nativeint(gsl_rng_min(Rng_val(rng)));
 }
 
 value ml_gsl_rng_get_type(value rng)
@@ -197,16 +197,16 @@ value ml_gsl_rng_set_state(value rng, value v)
   const char *name = String_val(Field(v, 0));
   value state = Field(v, 1);
   if(strcmp(name, gsl_rng_name(r)) != 0 ||
-     gsl_rng_size(r) != string_length(state) )
+     gsl_rng_size(r) != caml_string_length(state) )
     caml_invalid_argument("Gsl.Rng.set_state : wrong rng type");
-  memcpy(r->state, Bp_val(state), string_length(state));
+  memcpy(r->state, Bp_val(state), caml_string_length(state));
   return Val_unit;
 }
 
 /* sampling */
 value ml_gsl_rng_get(value rng)
 {
-  return copy_nativeint(gsl_rng_get(Rng_val(rng))) ;
+  return caml_copy_nativeint(gsl_rng_get(Rng_val(rng))) ;
 }
 
 value ml_gsl_rng_uniform(value rng)

--- a/src/mlgsl_rng.c
+++ b/src/mlgsl_rng.c
@@ -198,7 +198,7 @@ value ml_gsl_rng_set_state(value rng, value v)
   value state = Field(v, 1);
   if(strcmp(name, gsl_rng_name(r)) != 0 ||
      gsl_rng_size(r) != string_length(state) )
-    invalid_argument("Gsl.Rng.set_state : wrong rng type");
+    caml_invalid_argument("Gsl.Rng.set_state : wrong rng type");
   memcpy(r->state, Bp_val(state), string_length(state));
   return Val_unit;
 }

--- a/src/mlgsl_rng.c
+++ b/src/mlgsl_rng.c
@@ -145,7 +145,7 @@ value ml_gsl_rng_set(value rng, value seed)
 
 value ml_gsl_rng_name(value rng)
 {
-  return copy_string(gsl_rng_name(Rng_val(rng)));
+  return caml_copy_string(gsl_rng_name(Rng_val(rng)));
 }
 
 value ml_gsl_rng_max(value rng)
@@ -183,7 +183,7 @@ value ml_gsl_rng_dump_state(value rng)
   size_t len = gsl_rng_size(Rng_val(rng));
   void *state = gsl_rng_state(Rng_val(rng));
   const char *name = gsl_rng_name(Rng_val(rng));
-  n = copy_string(name);
+  n = caml_copy_string(name);
   s = caml_alloc_initialized_string(len, state);
   v = caml_alloc_small(2, 0);
   Field(v, 0) = n;

--- a/src/mlgsl_rng.c
+++ b/src/mlgsl_rng.c
@@ -185,7 +185,7 @@ value ml_gsl_rng_dump_state(value rng)
   const char *name = gsl_rng_name(Rng_val(rng));
   n = copy_string(name);
   s = caml_alloc_initialized_string(len, state);
-  v = alloc_small(2, 0);
+  v = caml_alloc_small(2, 0);
   Field(v, 0) = n;
   Field(v, 1) = s;
   CAMLreturn(v);

--- a/src/mlgsl_rng.c
+++ b/src/mlgsl_rng.c
@@ -211,12 +211,12 @@ value ml_gsl_rng_get(value rng)
 
 value ml_gsl_rng_uniform(value rng)
 {
-  return copy_double(gsl_rng_uniform(Rng_val(rng))) ;
+  return caml_copy_double(gsl_rng_uniform(Rng_val(rng))) ;
 }
 
 value ml_gsl_rng_uniform_pos(value rng)
 {
-  return copy_double(gsl_rng_uniform_pos(Rng_val(rng))) ;
+  return caml_copy_double(gsl_rng_uniform_pos(Rng_val(rng))) ;
 }
 
 value ml_gsl_rng_uniform_int(value rng, value n)

--- a/src/mlgsl_roots.c
+++ b/src/mlgsl_roots.c
@@ -40,7 +40,7 @@ CAMLprim value ml_gsl_root_fsolver_alloc(value t)
   {  
     CAMLparam0();
     CAMLlocal1(res);
-    res=alloc_small(2, Abstract_tag);
+    res=caml_alloc_small(2, Abstract_tag);
     Field(res, 0) = (value)s;
     Field(res, 1) = (value)params;
     params->gslfun.gf.function = &gslfun_callback;
@@ -64,7 +64,7 @@ CAMLprim value ml_gsl_root_fdfsolver_alloc(value t)
   {
     CAMLparam0();
     CAMLlocal1(res);
-    res=alloc_small(2, Abstract_tag);
+    res=caml_alloc_small(2, Abstract_tag);
     Field(res, 0) = (value)s;
     Field(res, 1) = (value)params;
     params->gslfun.gfdf.f      = &gslfun_callback_f;

--- a/src/mlgsl_roots.c
+++ b/src/mlgsl_roots.c
@@ -125,8 +125,8 @@ ML1(gsl_root_fdfsolver_name, FDFsolver_val, copy_string)
 
 ML1(gsl_root_fsolver_iterate, Fsolver_val, Unit)
 ML1(gsl_root_fdfsolver_iterate, FDFsolver_val, Unit)
-ML1(gsl_root_fsolver_root, Fsolver_val, copy_double)
-ML1(gsl_root_fdfsolver_root, FDFsolver_val, copy_double)
+ML1(gsl_root_fsolver_root, Fsolver_val, caml_copy_double)
+ML1(gsl_root_fdfsolver_root, FDFsolver_val, caml_copy_double)
 
 CAMLprim value ml_gsl_root_fsolver_x_interv(value S)
 {

--- a/src/mlgsl_roots.c
+++ b/src/mlgsl_roots.c
@@ -48,7 +48,7 @@ CAMLprim value ml_gsl_root_fsolver_alloc(value t)
     params->closure = Val_unit;
     params->dbl     = Val_unit;
 
-    register_global_root(&(params->closure));
+    caml_register_global_root(&(params->closure));
     CAMLreturn(res);
   }
 }
@@ -74,7 +74,7 @@ CAMLprim value ml_gsl_root_fdfsolver_alloc(value t)
     params->closure = Val_unit;
     params->dbl     = Val_unit;
 
-    register_global_root(&(params->closure));
+    caml_register_global_root(&(params->closure));
     CAMLreturn(res);
   }
 }
@@ -105,7 +105,7 @@ CAMLprim value ml_gsl_root_fdfsolver_set(value s, value f, value r)
 CAMLprim value ml_gsl_root_fsolver_free(value s)
 {
   struct callback_params *p=Fparams_val(s);
-  remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->closure));
   caml_stat_free(p);
   gsl_root_fsolver_free(Fsolver_val(s));
   return Val_unit;
@@ -114,7 +114,7 @@ CAMLprim value ml_gsl_root_fsolver_free(value s)
 CAMLprim value ml_gsl_root_fdfsolver_free(value s)
 {
   struct callback_params *p=Fparams_val(s);
-  remove_global_root(&(p->closure));
+  caml_remove_global_root(&(p->closure));
   caml_stat_free(p);
   gsl_root_fdfsolver_free(FDFsolver_val(s));
   return Val_unit;

--- a/src/mlgsl_roots.c
+++ b/src/mlgsl_roots.c
@@ -35,7 +35,7 @@ CAMLprim value ml_gsl_root_fsolver_alloc(value t)
   gsl_root_fsolver *s;
   
   s = gsl_root_fsolver_alloc(Fsolvertype_val(t));
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
 
   {  
     CAMLparam0();
@@ -59,7 +59,7 @@ CAMLprim value ml_gsl_root_fdfsolver_alloc(value t)
   gsl_root_fdfsolver *s;
   
   s = gsl_root_fdfsolver_alloc(FDFsolvertype_val(t)); 
-  params=stat_alloc(sizeof(*params));
+  params=caml_stat_alloc(sizeof(*params));
   
   {
     CAMLparam0();
@@ -106,7 +106,7 @@ CAMLprim value ml_gsl_root_fsolver_free(value s)
 {
   struct callback_params *p=Fparams_val(s);
   remove_global_root(&(p->closure));
-  stat_free(p);
+  caml_stat_free(p);
   gsl_root_fsolver_free(Fsolver_val(s));
   return Val_unit;
 }
@@ -115,7 +115,7 @@ CAMLprim value ml_gsl_root_fdfsolver_free(value s)
 {
   struct callback_params *p=Fparams_val(s);
   remove_global_root(&(p->closure));
-  stat_free(p);
+  caml_stat_free(p);
   gsl_root_fdfsolver_free(FDFsolver_val(s));
   return Val_unit;
 }

--- a/src/mlgsl_roots.c
+++ b/src/mlgsl_roots.c
@@ -120,8 +120,8 @@ CAMLprim value ml_gsl_root_fdfsolver_free(value s)
   return Val_unit;
 }
 
-ML1(gsl_root_fsolver_name, Fsolver_val, copy_string)
-ML1(gsl_root_fdfsolver_name, FDFsolver_val, copy_string)
+ML1(gsl_root_fsolver_name, Fsolver_val, caml_copy_string)
+ML1(gsl_root_fdfsolver_name, FDFsolver_val, caml_copy_string)
 
 ML1(gsl_root_fsolver_iterate, Fsolver_val, Unit)
 ML1(gsl_root_fdfsolver_iterate, FDFsolver_val, Unit)

--- a/src/mlgsl_sf.c
+++ b/src/mlgsl_sf.c
@@ -24,7 +24,7 @@ static value val_of_result_pair (gsl_sf_result *re, gsl_sf_result *im)
   CAMLlocal3 (v, v_re, v_im);
   v_re = val_of_result (re);
   v_im = val_of_result (im);
-  v = alloc_small (2, 0);
+  v = caml_alloc_small (2, 0);
   Field (v, 0) = v_re;
   Field (v, 1) = v_im;
   CAMLreturn (v);
@@ -36,7 +36,7 @@ static inline value val_of_result_e10(gsl_sf_result_e10 *result)
   CAMLlocal3(r, v, e) ;
   v = caml_copy_double(result->val);
   e = caml_copy_double(result->err);
-  r = alloc_small(3, 0);
+  r = caml_alloc_small(3, 0);
   Field(r, 0) = v;
   Field(r, 1) = e;
   Field(r, 2) = Val_int(result->e10);
@@ -368,7 +368,7 @@ CAMLprim value ml_gsl_sf_lngamma_sgn_e(value x)
     CAMLlocal3(v,r,s);
     r=val_of_result(&res);
     s=caml_copy_double(sgn);
-    v=alloc_small(2, 0);
+    v=caml_alloc_small(2, 0);
     Field(v, 0)=r;
     Field(v, 1)=s;
     CAMLreturn(v);
@@ -401,7 +401,7 @@ CAMLprim value ml_gsl_sf_lnpoch_sgn_e(value a, value x)
     CAMLlocal3(v,r,s);
     r=val_of_result(&res);
     s=caml_copy_double(sgn);
-    v=alloc_small(2, 0);
+    v=caml_alloc_small(2, 0);
     Field(v, 0)=r;
     Field(v, 1)=s;
     CAMLreturn(v);
@@ -423,7 +423,7 @@ CAMLprim value ml_gsl_sf_lnbeta_sgn_e(value x, value y)
     CAMLlocal3(v,r,s);
     r=val_of_result(&res);
     s=caml_copy_double(sgn);
-    v=alloc_small(2, 0);
+    v=caml_alloc_small(2, 0);
     Field(v, 0)=r;
     Field(v, 1)=s;
     CAMLreturn(v);

--- a/src/mlgsl_sf.c
+++ b/src/mlgsl_sf.c
@@ -269,7 +269,7 @@ CAMLprim value ml_gsl_sf_ellint_D(value arg1, value arg2, value arg3)
   double res =
     gsl_sf_ellint_D(
       Double_val(arg1), Double_val(arg2), dummy_n, GSL_MODE_val(arg3));
-  CAMLreturn(caml_caml_copy_double(res));
+  CAMLreturn(caml_copy_double(res));
 }
 
 CAMLprim value ml_gsl_sf_ellint_D_e(value arg1, value arg2, value arg3)

--- a/src/mlgsl_sf.c
+++ b/src/mlgsl_sf.c
@@ -34,8 +34,8 @@ static inline value val_of_result_e10(gsl_sf_result_e10 *result)
 {
   CAMLparam0();
   CAMLlocal3(r, v, e) ;
-  v = copy_double(result->val);
-  e = copy_double(result->err);
+  v = caml_copy_double(result->val);
+  e = caml_copy_double(result->err);
   r = alloc_small(3, 0);
   Field(r, 0) = v;
   Field(r, 1) = e;
@@ -84,19 +84,19 @@ CAMLprim value ml_gsl_sf_result_smash_e(value e10)
     return val_of_result(&res); }
 
 #define SF1(name, conv1) \
-  ML1(gsl_sf_##name, conv1, copy_double) \
+  ML1(gsl_sf_##name, conv1, caml_copy_double) \
   ML1_res(gsl_sf_##name##_e, conv1)
 #define SF2(name, conv1, conv2) \
-  ML2(gsl_sf_##name, conv1, conv2, copy_double) \
+  ML2(gsl_sf_##name, conv1, conv2, caml_copy_double) \
   ML2_res(gsl_sf_##name##_e, conv1, conv2)
 #define SF3(name, conv1, conv2, conv3) \
-  ML3(gsl_sf_##name, conv1, conv2, conv3, copy_double) \
+  ML3(gsl_sf_##name, conv1, conv2, conv3, caml_copy_double) \
   ML3_res(gsl_sf_##name##_e, conv1, conv2, conv3)
 #define SF4(name, conv1, conv2, conv3, conv4) \
-  ML4(gsl_sf_##name, conv1, conv2, conv3, conv4, copy_double) \
+  ML4(gsl_sf_##name, conv1, conv2, conv3, conv4, caml_copy_double) \
   ML4_res(gsl_sf_##name##_e, conv1, conv2, conv3, conv4)
 #define SF5(name, conv1, conv2, conv3, conv4, conv5) \
-  ML5(gsl_sf_##name, conv1, conv2, conv3, conv4, conv5, copy_double) \
+  ML5(gsl_sf_##name, conv1, conv2, conv3, conv4, conv5, caml_copy_double) \
   ML5_res(gsl_sf_##name##_e, conv1, conv2, conv3, conv4, conv5)
 
 
@@ -269,7 +269,7 @@ CAMLprim value ml_gsl_sf_ellint_D(value arg1, value arg2, value arg3)
   double res =
     gsl_sf_ellint_D(
       Double_val(arg1), Double_val(arg2), dummy_n, GSL_MODE_val(arg3));
-  CAMLreturn(caml_copy_double(res));
+  CAMLreturn(caml_caml_copy_double(res));
 }
 
 CAMLprim value ml_gsl_sf_ellint_D_e(value arg1, value arg2, value arg3)
@@ -367,7 +367,7 @@ CAMLprim value ml_gsl_sf_lngamma_sgn_e(value x)
     CAMLparam0();
     CAMLlocal3(v,r,s);
     r=val_of_result(&res);
-    s=copy_double(sgn);
+    s=caml_copy_double(sgn);
     v=alloc_small(2, 0);
     Field(v, 0)=r;
     Field(v, 1)=s;
@@ -400,7 +400,7 @@ CAMLprim value ml_gsl_sf_lnpoch_sgn_e(value a, value x)
     CAMLparam0();
     CAMLlocal3(v,r,s);
     r=val_of_result(&res);
-    s=copy_double(sgn);
+    s=caml_copy_double(sgn);
     v=alloc_small(2, 0);
     Field(v, 0)=r;
     Field(v, 1)=s;
@@ -422,7 +422,7 @@ CAMLprim value ml_gsl_sf_lnbeta_sgn_e(value x, value y)
     CAMLparam0();
     CAMLlocal3(v,r,s);
     r=val_of_result(&res);
-    s=copy_double(sgn);
+    s=caml_copy_double(sgn);
     v=alloc_small(2, 0);
     Field(v, 0)=r;
     Field(v, 1)=s;
@@ -614,8 +614,8 @@ CAMLprim value ml_gsl_sf_rect_to_polar(value x, value y)
   gsl_sf_rect_to_polar(Double_val(x), Double_val(y), &r, &theta);
   return val_of_result_pair (&r, &theta);
 }
-ML1(gsl_sf_angle_restrict_symm, Double_val, copy_double)
-ML1(gsl_sf_angle_restrict_pos, Double_val, copy_double)
+ML1(gsl_sf_angle_restrict_symm, Double_val, caml_copy_double)
+ML1(gsl_sf_angle_restrict_pos, Double_val, caml_copy_double)
 ML2_res(gsl_sf_sin_err_e, Double_val, Double_val)
 ML2_res(gsl_sf_cos_err_e, Double_val, Double_val)
 

--- a/src/mlgsl_stats.c
+++ b/src/mlgsl_stats.c
@@ -29,7 +29,7 @@ CAMLprim value ml_gsl_stats_mean(value ow, value data)
     result = gsl_stats_wmean(Double_array_val(w), 1, 
 			     Double_array_val(data), 1, len);
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_variance(value ow, value omean, value data)
@@ -53,7 +53,7 @@ CAMLprim value ml_gsl_stats_variance(value ow, value omean, value data)
 				     Double_array_val(data), 1, len, 
 				     Double_val(Unoption(omean)));
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_sd(value ow, value omean, value data)
@@ -77,7 +77,7 @@ CAMLprim value ml_gsl_stats_sd(value ow, value omean, value data)
 			       Double_array_val(data), 1, len, 
 			       Double_val(Unoption(omean)));
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_variance_with_fixed_mean(value ow,
@@ -95,7 +95,7 @@ CAMLprim value ml_gsl_stats_variance_with_fixed_mean(value ow,
 						 Double_array_val(data), 1,
 						 len, Double_val(mean));
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_sd_with_fixed_mean(value ow,
@@ -113,7 +113,7 @@ CAMLprim value ml_gsl_stats_sd_with_fixed_mean(value ow,
 					   Double_array_val(data), 1,
 					   len, Double_val(mean));
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_absdev(value ow, value omean, value data)
@@ -137,7 +137,7 @@ CAMLprim value ml_gsl_stats_absdev(value ow, value omean, value data)
 				   Double_array_val(data), 1, len, 
 				   Double_val(Unoption(omean)));
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_skew(value ow, value data)
@@ -152,7 +152,7 @@ CAMLprim value ml_gsl_stats_skew(value ow, value data)
     result = gsl_stats_wskew(Double_array_val(w), 1, 
 			     Double_array_val(data), 1, len);
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_skew_m_sd(value ow, value mean, 
@@ -170,7 +170,7 @@ CAMLprim value ml_gsl_stats_skew_m_sd(value ow, value mean,
 				  Double_array_val(data), 1, len,
 				  Double_val(mean), Double_val(sd));
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_kurtosis(value ow, value data)
@@ -185,7 +185,7 @@ CAMLprim value ml_gsl_stats_kurtosis(value ow, value data)
     result = gsl_stats_wkurtosis(Double_array_val(w), 1,
 				 Double_array_val(data), 1, len);
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_kurtosis_m_sd(value ow, value mean, 
@@ -203,7 +203,7 @@ CAMLprim value ml_gsl_stats_kurtosis_m_sd(value ow, value mean,
 				      Double_array_val(data), 1, len,
 				      Double_val(mean), Double_val(sd));
   }
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_lag1_autocorrelation(value omean, value data)
@@ -215,7 +215,7 @@ CAMLprim value ml_gsl_stats_lag1_autocorrelation(value omean, value data)
   else
     result = gsl_stats_lag1_autocorrelation_m(Double_array_val(data), 1, len, 
 					      Double_val(Unoption(omean)));
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_covariance(value data1, value data2)
@@ -225,7 +225,7 @@ CAMLprim value ml_gsl_stats_covariance(value data1, value data2)
   check_array_size(data1, data2);
   result = gsl_stats_covariance(Double_array_val(data1), 1,
 				Double_array_val(data2), 1, len);
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_covariance_m(value mean1, value data1,
@@ -237,21 +237,21 @@ CAMLprim value ml_gsl_stats_covariance_m(value mean1, value data1,
   result = gsl_stats_covariance_m(Double_array_val(data1), 1, 
 				  Double_array_val(data2), 1, len,
 				  Double_val(mean1), Double_val(mean2));
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_max(value data)
 {
   size_t len = Double_array_length(data);
   double result = gsl_stats_max(Double_array_val(data), 1, len);
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_min(value data)
 {
   size_t len = Double_array_length(data);
   double result = gsl_stats_min(Double_array_val(data), 1, len);
-  return copy_double(result);
+  return caml_copy_double(result);
 }
 
 CAMLprim value ml_gsl_stats_minmax(value data)
@@ -293,7 +293,7 @@ CAMLprim value ml_gsl_stats_quantile_from_sorted_data(value data, value f)
   size_t len = Double_array_length(data);
   double r = gsl_stats_quantile_from_sorted_data(Double_array_val(data),
 						 1, len, Double_val(f));
-  return copy_double(r);
+  return caml_copy_double(r);
 }
 
 CAMLprim value ml_gsl_stats_correlation(value data1, value data2)
@@ -303,5 +303,5 @@ CAMLprim value ml_gsl_stats_correlation(value data1, value data2)
   check_array_size(data1, data2);
   r = gsl_stats_correlation(Double_array_val(data1), 1,
                             Double_array_val(data2), 1, len);
-  return copy_double(r);
+  return caml_copy_double(r);
 }

--- a/src/mlgsl_stats.c
+++ b/src/mlgsl_stats.c
@@ -282,7 +282,7 @@ CAMLprim value ml_gsl_stats_minmax_index(value data)
   size_t mi, ma;
   value r;
   gsl_stats_minmax_index(&mi, &ma, Double_array_val(data), 1, len);
-  r = alloc_small(2, 0);
+  r = caml_alloc_small(2, 0);
   Field(r, 0) = Val_int(mi);
   Field(r, 1) = Val_int(ma);
   return r;

--- a/src/mlgsl_sum.c
+++ b/src/mlgsl_sum.c
@@ -27,7 +27,7 @@ CAMLprim value ml_gsl_sum_levin_u_getinfo(value ws)
   CAMLparam0();
   CAMLlocal2(v, s);
   s=caml_copy_double(W->sum_plain);
-  v=alloc_small(3, 0);
+  v=caml_alloc_small(3, 0);
   Field(v, 0)=Val_int(W->size);
   Field(v, 1)=Val_int(W->terms_used);
   Field(v, 2)=s;
@@ -52,7 +52,7 @@ CAMLprim value ml_gsl_sum_levin_utrunc_getinfo(value ws)
   CAMLparam0();
   CAMLlocal2(v, s);
   s=caml_copy_double(W->sum_plain);
-  v=alloc_small(3, 0);
+  v=caml_alloc_small(3, 0);
   Field(v, 0)=Val_int(W->size);
   Field(v, 1)=Val_int(W->terms_used);
   Field(v, 2)=s;

--- a/src/mlgsl_sum.c
+++ b/src/mlgsl_sum.c
@@ -26,7 +26,7 @@ CAMLprim value ml_gsl_sum_levin_u_getinfo(value ws)
   gsl_sum_levin_u_workspace *W=WS_val(ws);
   CAMLparam0();
   CAMLlocal2(v, s);
-  s=copy_double(W->sum_plain);
+  s=caml_copy_double(W->sum_plain);
   v=alloc_small(3, 0);
   Field(v, 0)=Val_int(W->size);
   Field(v, 1)=Val_int(W->terms_used);
@@ -51,7 +51,7 @@ CAMLprim value ml_gsl_sum_levin_utrunc_getinfo(value ws)
   gsl_sum_levin_utrunc_workspace *W=WStrunc_val(ws);
   CAMLparam0();
   CAMLlocal2(v, s);
-  s=copy_double(W->sum_plain);
+  s=caml_copy_double(W->sum_plain);
   v=alloc_small(3, 0);
   Field(v, 0)=Val_int(W->size);
   Field(v, 1)=Val_int(W->terms_used);

--- a/src/mlgsl_vector.h
+++ b/src/mlgsl_vector.h
@@ -14,7 +14,7 @@
 
 static inline void TYPE(mlgsl_vec_of_bigarray)(TYPE(gsl_vector) *cvec, 
 					       value vvec){
-  struct caml_bigarray *bigarr = Caml_ba_array_val(vvec);
+  struct caml_ba_array *bigarr = Caml_ba_array_val(vvec);
   cvec->block = NULL;
   cvec->owner = 0;
   cvec->size   = bigarr->dim[0];

--- a/src/mlgsl_vector.h
+++ b/src/mlgsl_vector.h
@@ -14,7 +14,7 @@
 
 static inline void TYPE(mlgsl_vec_of_bigarray)(TYPE(gsl_vector) *cvec, 
 					       value vvec){
-  struct caml_bigarray *bigarr = Bigarray_val(vvec);
+  struct caml_bigarray *bigarr = Caml_ba_array_val(vvec);
   cvec->block = NULL;
   cvec->owner = 0;
   cvec->size   = bigarr->dim[0];

--- a/src/mlgsl_vector_impl.h
+++ b/src/mlgsl_vector_impl.h
@@ -117,7 +117,7 @@ CAMLprim value FUNCTION(ml_gsl_vector,minmaxindex)(value a)
   _DECLARE_VECTOR(a);
   _CONVERT_VECTOR(a);
   FUNCTION(gsl_vector,minmax_index)(&v_a, &x, &y);
-  v=alloc_small(2, 0);
+  v=caml_alloc_small(2, 0);
   Field(v, 0) = Val_int(x);
   Field(v, 1) = Val_int(y);
   return v;

--- a/src/mlgsl_vector_impl.h
+++ b/src/mlgsl_vector_impl.h
@@ -77,14 +77,14 @@ CAMLprim value FUNCTION(ml_gsl_vector,max)(value a)
 {
   _DECLARE_VECTOR(a);
   _CONVERT_VECTOR(a);
-  return copy_double(FUNCTION(gsl_vector,max)(&v_a));
+  return caml_copy_double(FUNCTION(gsl_vector,max)(&v_a));
 }
 
 CAMLprim value FUNCTION(ml_gsl_vector,min)(value a)
 {
   _DECLARE_VECTOR(a);
   _CONVERT_VECTOR(a);
-  return copy_double(FUNCTION(gsl_vector,min)(&v_a));
+  return caml_copy_double(FUNCTION(gsl_vector,min)(&v_a));
 }
 
 CAMLprim value FUNCTION(ml_gsl_vector,minmax)(value a)

--- a/src/mlgsl_wavelet.c
+++ b/src/mlgsl_wavelet.c
@@ -39,7 +39,7 @@ ml_gsl_wavelet_alloc (value ty, value k)
 #define Wavelet_val(v) (gsl_wavelet *)Field(v, 0)
 
 ML1 (gsl_wavelet_free, Wavelet_val, Unit)
-ML1 (gsl_wavelet_name, Wavelet_val, copy_string)
+ML1 (gsl_wavelet_name, Wavelet_val, caml_copy_string)
 
 CAMLprim value
 ml_gsl_wavelet_workspace_alloc (value n)

--- a/src/mlgsl_wavelet.c
+++ b/src/mlgsl_wavelet.c
@@ -96,7 +96,7 @@ ml_gsl_wavelet_transform (value w, value dir, value vf, value ws)
 CAMLprim value
 ml_gsl_wavelet_transform_bigarray (value w, value dir, value b, value ws)
 {
-  struct caml_bigarray *bigarr = Caml_ba_array_val(b);
+  struct caml_ba_array *bigarr = Caml_ba_array_val(b);
   double *data  = bigarr->data;
   size_t n      = bigarr->dim[0];
   gsl_wavelet_transform (Wavelet_val (w), data, 1, n,

--- a/src/mlgsl_wavelet.c
+++ b/src/mlgsl_wavelet.c
@@ -96,7 +96,7 @@ ml_gsl_wavelet_transform (value w, value dir, value vf, value ws)
 CAMLprim value
 ml_gsl_wavelet_transform_bigarray (value w, value dir, value b, value ws)
 {
-  struct caml_bigarray *bigarr = Bigarray_val(b);
+  struct caml_bigarray *bigarr = Caml_ba_array_val(b);
   double *data  = bigarr->data;
   size_t n      = bigarr->dim[0];
   gsl_wavelet_transform (Wavelet_val (w), data, 1, n,

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -30,8 +30,8 @@ static inline value copy_two_double(double a, double b)
 {
   CAMLparam0();
   CAMLlocal3(r, va, vb);
-  va = copy_double(a);
-  vb = copy_double(b);
+  va = caml_copy_double(a);
+  vb = caml_copy_double(b);
   r = alloc_small(2, 0);
   Field(r, 0) = va;
   Field(r, 1) = vb;

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -32,7 +32,7 @@ static inline value copy_two_double(double a, double b)
   CAMLlocal3(r, va, vb);
   va = caml_copy_double(a);
   vb = caml_copy_double(b);
-  r = alloc_small(2, 0);
+  r = caml_alloc_small(2, 0);
   Field(r, 0) = va;
   Field(r, 1) = vb;
   CAMLreturn(r);
@@ -41,14 +41,14 @@ static inline value copy_two_double(double a, double b)
 static inline value copy_two_double_arr(double a, double b)
 {
   value r;
-  r=alloc_small(2 * Double_wosize, Double_array_tag);
+  r=caml_alloc_small(2 * Double_wosize, Double_array_tag);
   Store_double_field(r, 0, a);
   Store_double_field(r, 1, b);
   return r;
 }
 
 #define Abstract_ptr(v, p) \
-  ( v=alloc_small(1, Abstract_tag), Field(v, 0)=Val_bp(p) )
+  ( v=caml_alloc_small(1, Abstract_tag), Field(v, 0)=Val_bp(p) )
 
 #define ML1(name, conv1, convr) \
   CAMLprim value ml_##name(value arg1) \


### PR DESCRIPTION
This PR makes `gsl-ocaml` compatible with OCaml 5 by replacing the use of function short names (e.g `copy_double`) (which were removed in OCaml 5) by their full names (e.g. `caml_copy_double`) . 

There is also a small fix that use an explicit cast to work around the fact that the `Field` macro returns now a `volatile` value, and another which adds the `unix` library as a dependency to the various examples.