### PR TITLE
Link the blas library after gsl

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -52,7 +52,7 @@ let () =
         List.filter (fun x -> not (String.equal x "-lgslcblas")) conf.libs
       in
       match Sys.getenv_opt "GSL_CBLAS_LIB" with
-      | Some alt_blas -> { conf with libs = alt_blas :: without_cblas () }
+      | Some alt_blas -> { conf with libs = without_cblas () @ [alt_blas] }
       | None ->
           Option.value_map ~default:conf (C.ocaml_config_var c "system")
             ~f:(function


### PR DESCRIPTION
I did a test build of gsl-ocaml 1.25.0 for Fedora Rawhide and got a library that was linked with gsl, but not with any blas library, so there are unresolved symbols.  There are multiple factors involved:
- Fedora adds `-Wl,--as-needed` to the default linker flags
- Fedora uses [flexiblas](https://www.mpi-magdeburg.mpg.de/projects/flexiblas) as the blas library, so we set `GSL_CBLAS_LIB` in in the ocaml-gsl build
- In discover.ml, the `GSL_CBLAS_LIB` case adds the blas library at the front of the linker flags, before `-lgsl`.

When the blas library is linked, it doesn't resolve any symbols, since gsl-ocaml itself does not directly use them.  Because of `-Wl,--as-needed`, the blas library is therefore not linked into the final ELF object.

This PR moves the blas library after `-lgsl` so that it is used to resolve symbols in libgsl.